### PR TITLE
[feat/#22] Apple을 제외한 나머지 OAuth 모두 구현

### DIFF
--- a/src/main/java/goodspace/backend/authorization/controller/AccessTokenReissueController.java
+++ b/src/main/java/goodspace/backend/authorization/controller/AccessTokenReissueController.java
@@ -1,0 +1,34 @@
+package goodspace.backend.authorization.controller;
+
+import goodspace.backend.authorization.dto.request.AccessTokenReissueRequestDto;
+import goodspace.backend.authorization.dto.response.AccessTokenResponseDto;
+import goodspace.backend.authorization.service.AccessTokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/authorization")
+@RequiredArgsConstructor
+@Tag(
+        name = "토큰 재발급 API",
+        description = "리프레쉬 토큰을 통해 엑세스 토큰을 재발급"
+)
+public class AccessTokenReissueController {
+    private final AccessTokenService accessTokenService;
+
+    @PostMapping("/reissue")
+    @Operation(
+            summary = "토큰 재발급",
+            description = "리프레쉬 토큰을 통해 엑세스 토큰을 재발급합니다"
+    )
+    public ResponseEntity<AccessTokenResponseDto> reissueAccessToken(AccessTokenReissueRequestDto requestDto) {
+        AccessTokenResponseDto responseDto = accessTokenService.reissue(requestDto);
+
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/src/main/java/goodspace/backend/authorization/controller/GoodSpaceAuthorizationController.java
+++ b/src/main/java/goodspace/backend/authorization/controller/GoodSpaceAuthorizationController.java
@@ -1,11 +1,9 @@
 package goodspace.backend.authorization.controller;
 
-import goodspace.backend.authorization.dto.request.AccessTokenReissueRequestDto;
 import goodspace.backend.authorization.dto.request.SignInRequestDto;
 import goodspace.backend.authorization.dto.request.SignUpRequestDto;
-import goodspace.backend.authorization.dto.response.AccessTokenResponseDto;
 import goodspace.backend.authorization.dto.response.TokenResponseDto;
-import goodspace.backend.authorization.service.GoodSpaceAuthorizationService;
+import goodspace.backend.authorization.service.goodspace.GoodSpaceAuthorizationService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AllArgsConstructor;
@@ -25,9 +23,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class GoodSpaceAuthorizationController {
     private final GoodSpaceAuthorizationService goodSpaceAuthorizationService;
 
-    @PostMapping("/signUp")
+    @PostMapping("/sign-up")
     @Operation(
-            summary = "자체 회원가입",
+            summary = "회원가입",
             description = "전달받은 정보를 통해 새로운 회원을 생성합니다"
     )
     public ResponseEntity<TokenResponseDto> signUp(SignUpRequestDto requestDto) {
@@ -36,24 +34,13 @@ public class GoodSpaceAuthorizationController {
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
-    @PostMapping("/signIn")
+    @PostMapping("/sign-in")
     @Operation(
-            summary = "자체 로그인",
+            summary = "로그인",
             description = "이메일과 비밀번호를 통해 사용자를 인증하고 JWT 토큰을 발급합니다"
     )
     public ResponseEntity<TokenResponseDto> signIn(SignInRequestDto requestDto) {
         TokenResponseDto responseDto = goodSpaceAuthorizationService.signIn(requestDto);
-
-        return ResponseEntity.ok(responseDto);
-    }
-
-    @PostMapping("/reissue")
-    @Operation(
-            summary = "토큰 재발급",
-            description = "리프레쉬 토큰을 통해 엑세스 토큰을 재발급합니다"
-    )
-    public ResponseEntity<AccessTokenResponseDto> reissueAccessToken(AccessTokenReissueRequestDto requestDto) {
-        AccessTokenResponseDto responseDto = goodSpaceAuthorizationService.reissueAccessToken(requestDto);
 
         return ResponseEntity.ok(responseDto);
     }

--- a/src/main/java/goodspace/backend/authorization/controller/OAuthController.java
+++ b/src/main/java/goodspace/backend/authorization/controller/OAuthController.java
@@ -1,0 +1,124 @@
+package goodspace.backend.authorization.controller;
+
+import goodspace.backend.authorization.dto.response.TokenResponseDto;
+import goodspace.backend.authorization.service.facebook.FacebookOAuthService;
+import goodspace.backend.authorization.service.google.GoogleOAuthService;
+import goodspace.backend.authorization.service.kakao.KaKaoOAuthService;
+import goodspace.backend.authorization.service.naver.NaverOAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.SEE_OTHER;
+
+@RestController
+@RequestMapping("/authorization")
+@RequiredArgsConstructor
+@Tag(
+        name = "OAuth API",
+        description = "소셜 회원가입, 로그인 관련 기능"
+)
+public class OAuthController {
+    private final GoogleOAuthService googleOAuthService;
+    private final KaKaoOAuthService kaKaoOAuthService;
+    private final FacebookOAuthService facebookOAuthService;
+    private final NaverOAuthService naverOAuthService;
+
+    @GetMapping("/google")
+    @Operation(
+            summary = "구글 소셜 로그인/회원가입",
+            description = "구글을 통해 사용자를 인증하고 JWT를 발급합니다"
+    )
+    public ResponseEntity<TokenResponseDto> googleAuthorization(@RequestParam(name = "code") String code) {
+        String accessToken = googleOAuthService.getAccessToken(code);
+        TokenResponseDto responseDto = googleOAuthService.signUpOrSignIn(accessToken);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/google/redirection")
+    @Operation(
+            summary = "구글 로그인 화면 리다이렉트",
+            description = "구글 로그인 화면으로 리다이렉트합니다"
+    )
+    public ResponseEntity<Void> googleRedirect() {
+        return ResponseEntity.status(SEE_OTHER)
+                .header(HttpHeaders.LOCATION, googleOAuthService.getOauthPageRedirectUrl())
+                .build();
+    }
+
+    @GetMapping("/kakao")
+    @Operation(
+            summary = "카카오 소셜 로그인",
+            description = "카카오를 통해 사용자를 인증하고 JWT를 발급합니다"
+    )
+    public ResponseEntity<TokenResponseDto> kakaoAuthorization(@RequestParam(name = "code") String code) {
+        String accessToken = kaKaoOAuthService.getAccessToken(code);
+        TokenResponseDto responseDto = kaKaoOAuthService.signUpOrSignIn(accessToken);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/kakao/redirection")
+    @Operation(
+            summary = "카카오 로그인 화면 리다이렉트",
+            description = "카카오 로그인 화면으로 리다이렉트합니다"
+    )
+    public ResponseEntity<Void> kakaoRedirect() {
+        return ResponseEntity.status(SEE_OTHER)
+                .header(HttpHeaders.LOCATION, kaKaoOAuthService.getOauthPageRedirectUrl())
+                .build();
+    }
+
+    @GetMapping("/facebook")
+    @Operation(
+            summary = "페이스북 소셜 로그인",
+            description = "페이스북을 통해 사용자를 인증하고 JWT를 발급합니다"
+    )
+    public ResponseEntity<TokenResponseDto> facebookAuthorization(@RequestParam(name = "code") String code) {
+        String accessToken = facebookOAuthService.getAccessToken(code);
+        TokenResponseDto responseDto = facebookOAuthService.signUpOrSignIn(accessToken);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/facebook/redirection")
+    @Operation(
+            summary = "페이스북 로그인 화면 리다이렉트",
+            description = "페이스북 로그인 화면으로 리다이렉트합니다"
+    )
+    public ResponseEntity<Void> facebookRedirect() {
+        return ResponseEntity.status(SEE_OTHER)
+                .header(HttpHeaders.LOCATION, facebookOAuthService.getOauthPageRedirectUrl())
+                .build();
+    }
+
+    @GetMapping("/naver")
+    @Operation(
+            summary = "네이버 소셜 로그인",
+            description = "네이버를 통해 사용자를 인증하고 JWT를 발급합니다"
+    )
+    public ResponseEntity<TokenResponseDto> naverAuthorization(@RequestParam(name = "code") String code) {
+        String accessToken = naverOAuthService.getAccessToken(code);
+        TokenResponseDto responseDto = naverOAuthService.signUpOrSignIn(accessToken);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/naver/redirection")
+    @Operation(
+            summary = "네이버 로그인 화면 리다이렉트",
+            description = "네이버 로그인 화면으로 리다이렉트합니다"
+    )
+    public ResponseEntity<Void> naverRedirect() {
+        return ResponseEntity.status(SEE_OTHER)
+                .header(HttpHeaders.LOCATION, naverOAuthService.getOauthPageRedirectUrl())
+                .build();
+    }
+}

--- a/src/main/java/goodspace/backend/authorization/dto/facebook/FacebookAccessTokenDto.java
+++ b/src/main/java/goodspace/backend/authorization/dto/facebook/FacebookAccessTokenDto.java
@@ -1,0 +1,14 @@
+package goodspace.backend.authorization.dto.facebook;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+
+@Getter
+public class FacebookAccessTokenDto {
+    @SerializedName("access_token")
+    private String accessToken;
+    @SerializedName("token_type")
+    private String tokenType;
+    @SerializedName("expires_in")
+    private Long expiresIn;
+}

--- a/src/main/java/goodspace/backend/authorization/dto/facebook/FacebookUserInfoDto.java
+++ b/src/main/java/goodspace/backend/authorization/dto/facebook/FacebookUserInfoDto.java
@@ -1,0 +1,23 @@
+package goodspace.backend.authorization.dto.facebook;
+
+import com.google.gson.annotations.SerializedName;
+import goodspace.backend.domain.user.OAuthUser;
+import lombok.Getter;
+
+import static goodspace.backend.domain.user.OAuthType.FACEBOOK;
+
+@Getter
+public class FacebookUserInfoDto {
+    @SerializedName("id")
+    private String id;
+    @SerializedName("email")
+    private String email;
+
+    public OAuthUser toEntity() {
+        return OAuthUser.builder()
+                .identifier(id)
+                .email(email)
+                .oauthType(FACEBOOK)
+                .build();
+    }
+}

--- a/src/main/java/goodspace/backend/authorization/dto/google/GoogleAccessTokenDto.java
+++ b/src/main/java/goodspace/backend/authorization/dto/google/GoogleAccessTokenDto.java
@@ -1,0 +1,14 @@
+package goodspace.backend.authorization.dto.google;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GoogleAccessTokenDto {
+    @SerializedName("access_token")
+    private String accessToken;
+}

--- a/src/main/java/goodspace/backend/authorization/dto/google/GoogleUserInfoDto.java
+++ b/src/main/java/goodspace/backend/authorization/dto/google/GoogleUserInfoDto.java
@@ -1,0 +1,30 @@
+package goodspace.backend.authorization.dto.google;
+
+import com.google.gson.annotations.SerializedName;
+import goodspace.backend.domain.user.OAuthUser;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static goodspace.backend.domain.user.OAuthType.GOOGLE;
+
+@Getter
+@AllArgsConstructor
+public class GoogleUserInfoDto {
+    private String id;
+    private String email;
+    private String name;
+    private String givenName;
+    private String familyName;
+    @SerializedName("picture")
+    private String pictureUrl;
+    private String locale;
+
+    public OAuthUser toEntity() {
+        return OAuthUser.builder()
+                .identifier(id)
+                .email(email)
+                .name(name)
+                .oauthType(GOOGLE)
+                .build();
+    }
+}

--- a/src/main/java/goodspace/backend/authorization/dto/kakao/KakaoAccessTokenDto.java
+++ b/src/main/java/goodspace/backend/authorization/dto/kakao/KakaoAccessTokenDto.java
@@ -1,0 +1,10 @@
+package goodspace.backend.authorization.dto.kakao;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+
+@Getter
+public class KakaoAccessTokenDto {
+    @SerializedName("access_token")
+    private String accessToken;
+}

--- a/src/main/java/goodspace/backend/authorization/dto/kakao/KakaoUserInfoDto.java
+++ b/src/main/java/goodspace/backend/authorization/dto/kakao/KakaoUserInfoDto.java
@@ -1,0 +1,52 @@
+package goodspace.backend.authorization.dto.kakao;
+
+import com.google.gson.annotations.SerializedName;
+import goodspace.backend.domain.user.OAuthUser;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static goodspace.backend.domain.user.OAuthType.KAKAO;
+
+/**
+ * 참고 문서: <a href="https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info">...</a>
+ */
+@Getter
+@AllArgsConstructor
+public class KakaoUserInfoDto {
+    private String id;
+
+    @SerializedName("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @Getter
+    @AllArgsConstructor
+    static class KakaoAccount {
+        @SerializedName("email_needs_agreement")
+        private Boolean emailNeedsAgreement;
+        @SerializedName("is_email_valid")
+        private Boolean isEmailValid;
+        @SerializedName("is_email_verified")
+        private Boolean getIsEmailVerified;
+        private String email;
+    }
+
+    public String getEmail() {
+        return this.kakaoAccount.email;
+    }
+
+    public Boolean isValidatedEmail() {
+        if (kakaoAccount.isEmailValid == null || kakaoAccount.getIsEmailVerified == null) {
+            return false;
+        }
+
+        return kakaoAccount.isEmailValid && kakaoAccount.getIsEmailVerified;
+    }
+
+    public OAuthUser toEntity() {
+            return OAuthUser.builder()
+                    .identifier(id)
+                    .email(kakaoAccount.email)
+                    .oauthType(KAKAO)
+                    .build();
+    }
+}

--- a/src/main/java/goodspace/backend/authorization/dto/naver/NaverAccessTokenDto.java
+++ b/src/main/java/goodspace/backend/authorization/dto/naver/NaverAccessTokenDto.java
@@ -1,0 +1,10 @@
+package goodspace.backend.authorization.dto.naver;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+
+@Getter
+public class NaverAccessTokenDto {
+    @SerializedName("access_token")
+    private String accessToken;
+}

--- a/src/main/java/goodspace/backend/authorization/dto/naver/NaverUserInfoDto.java
+++ b/src/main/java/goodspace/backend/authorization/dto/naver/NaverUserInfoDto.java
@@ -1,0 +1,42 @@
+package goodspace.backend.authorization.dto.naver;
+
+import goodspace.backend.domain.user.OAuthUser;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static goodspace.backend.domain.user.OAuthType.NAVER;
+
+/**
+ * 참고 문서: <a href="https://developers.naver.com/docs/login/profile/profile.md">...</a>
+ */
+@Getter
+@AllArgsConstructor
+public class NaverUserInfoDto {
+    private String resultCode;
+    private String message;
+
+    private Response response;
+
+    @Getter
+    @AllArgsConstructor
+    static class Response {
+        private String id;
+        private String email;
+    }
+
+    public String getId() {
+        return response.id;
+    }
+
+    public String getEmail() {
+        return response.email;
+    }
+
+    public OAuthUser toEntity() {
+            return OAuthUser.builder()
+                    .identifier(response.id)
+                    .email(response.email)
+                    .oauthType(NAVER)
+                    .build();
+    }
+}

--- a/src/main/java/goodspace/backend/authorization/service/AccessTokenService.java
+++ b/src/main/java/goodspace/backend/authorization/service/AccessTokenService.java
@@ -1,0 +1,8 @@
+package goodspace.backend.authorization.service;
+
+import goodspace.backend.authorization.dto.request.AccessTokenReissueRequestDto;
+import goodspace.backend.authorization.dto.response.AccessTokenResponseDto;
+
+public interface AccessTokenService {
+    AccessTokenResponseDto reissue(AccessTokenReissueRequestDto requestDto);
+}

--- a/src/main/java/goodspace/backend/authorization/service/AccessTokenServiceImpl.java
+++ b/src/main/java/goodspace/backend/authorization/service/AccessTokenServiceImpl.java
@@ -1,0 +1,45 @@
+package goodspace.backend.authorization.service;
+
+import goodspace.backend.authorization.dto.request.AccessTokenReissueRequestDto;
+import goodspace.backend.authorization.dto.response.AccessTokenResponseDto;
+import goodspace.backend.domain.user.User;
+import goodspace.backend.repository.UserRepository;
+import goodspace.backend.security.TokenProvider;
+import goodspace.backend.security.TokenType;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.function.Supplier;
+
+@Service
+@AllArgsConstructor
+public class AccessTokenServiceImpl implements AccessTokenService {
+    private static final Supplier<EntityNotFoundException> USER_NOT_FOUND = () -> new EntityNotFoundException("회원을 찾을 수 없습니다.");
+    private static final Supplier<IllegalArgumentException> EXPIRED_TOKEN = () -> new IllegalArgumentException("만료된 토큰입니다.");
+
+    private final UserRepository userRepository;
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    @Transactional(readOnly = true)
+    public AccessTokenResponseDto reissue(AccessTokenReissueRequestDto requestDto) {
+        String refreshToken = requestDto.refreshToken();
+        long userId = tokenProvider.getIdFromToken(refreshToken);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(USER_NOT_FOUND);
+
+        String existsRefreshToken = user.getRefreshToken();
+
+        if (!refreshToken.equals(existsRefreshToken)) {
+            throw EXPIRED_TOKEN.get();
+        }
+
+        return AccessTokenResponseDto.builder()
+                .accessToken(tokenProvider.createToken(userId, TokenType.ACCESS))
+                .build();
+    }
+}

--- a/src/main/java/goodspace/backend/authorization/service/OAuthService.java
+++ b/src/main/java/goodspace/backend/authorization/service/OAuthService.java
@@ -1,0 +1,11 @@
+package goodspace.backend.authorization.service;
+
+import goodspace.backend.authorization.dto.response.TokenResponseDto;
+
+public interface OAuthService {
+    String getAccessToken(String code);
+
+    TokenResponseDto signUpOrSignIn(String accessToken);
+
+    String getOauthPageRedirectUrl();
+}

--- a/src/main/java/goodspace/backend/authorization/service/facebook/FacebookOAuthService.java
+++ b/src/main/java/goodspace/backend/authorization/service/facebook/FacebookOAuthService.java
@@ -1,0 +1,147 @@
+package goodspace.backend.authorization.service.facebook;
+
+import com.google.gson.Gson;
+import goodspace.backend.authorization.dto.facebook.FacebookAccessTokenDto;
+import goodspace.backend.authorization.dto.facebook.FacebookUserInfoDto;
+import goodspace.backend.authorization.dto.response.TokenResponseDto;
+import goodspace.backend.authorization.service.OAuthService;
+import goodspace.backend.domain.user.User;
+import goodspace.backend.repository.UserRepository;
+import goodspace.backend.security.TokenProvider;
+import goodspace.backend.security.TokenType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import static goodspace.backend.domain.user.OAuthType.FACEBOOK;
+
+@Service
+@Slf4j
+public class FacebookOAuthService implements OAuthService {
+
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+
+    private static final String TOKEN_BASE_URL = "https://graph.facebook.com/v14.0/oauth/access_token";
+    private static final String USER_INFO_BASE_URL = "https://graph.facebook.com/me?fields=id,email";
+    private static final String OAUTH_PAGE_REDIRECT_BASE_URL = "https://www.facebook.com/v14.0/dialog/oauth";
+    private static final String SCOPE = "email";
+
+    private final String CLIENT_ID;
+    private final String CLIENT_SECRET;
+    private final String REDIRECT_URI;
+
+    public FacebookOAuthService(
+            UserRepository userRepository,
+            TokenProvider tokenProvider,
+            @Value("${keys.facebook.client-id}") String clientId,
+            @Value("${keys.facebook.client-secret}") String clientSecret,
+            @Value("${keys.facebook.redirect-uri}") String redirectUri
+    ) {
+        this.userRepository = userRepository;
+        this.tokenProvider = tokenProvider;
+        this.CLIENT_ID = clientId;
+        this.CLIENT_SECRET = clientSecret;
+        this.REDIRECT_URI = redirectUri;
+    }
+
+    @Override
+    public String getAccessToken(String code) {
+        String url = getTokenUrl(code);
+        ResponseEntity<String> response = sendTokenRequest(url);
+
+        if (isRequestFailed(response)) {
+            log.warn(
+                    "페이스북으로부터 엑세스 토큰을 획득하지 못했습니다. 상태코드 {}: {}",
+                    response.getStatusCode(),
+                    response.getBody()
+            );
+            throw new RuntimeException("페이스북 엑세스 토큰 획득 실패");
+        }
+
+        return getAccessTokenFromResponse(response);
+    }
+
+    @Override
+    @Transactional
+    public TokenResponseDto signUpOrSignIn(String facebookAccessToken) {
+        FacebookUserInfoDto facebookUserInfo = getFacebookUserInfo(facebookAccessToken);
+
+        User user = userRepository.findByIdentifierAndOAuthType(facebookUserInfo.getId(), FACEBOOK)
+                .orElseGet(() -> userRepository.save(facebookUserInfo.toEntity()));
+
+        String accessTokenValue = tokenProvider.createToken(user.getId(), TokenType.ACCESS);
+        String refreshTokenValue = tokenProvider.createToken(user.getId(), TokenType.REFRESH);
+        user.updateRefreshToken(refreshTokenValue);
+
+        return new TokenResponseDto(accessTokenValue, refreshTokenValue);
+    }
+
+    @Override
+    public String getOauthPageRedirectUrl() {
+        return OAUTH_PAGE_REDIRECT_BASE_URL +
+                "?client_id=" + CLIENT_ID +
+                "&redirect_uri=" + REDIRECT_URI +
+                "&response_type=code" +
+                "&scope=" + SCOPE;
+    }
+
+    private String getTokenUrl(String code) {
+        return TOKEN_BASE_URL +
+                "?client_id=" + CLIENT_ID +
+                "&redirect_uri=" + REDIRECT_URI +
+                "&client_secret=" + CLIENT_SECRET +
+                "&code=" + code;
+    }
+
+    private ResponseEntity<String> sendTokenRequest(String url) {
+        return new RestTemplate().getForEntity(url, String.class);
+    }
+
+    private String getAccessTokenFromResponse(ResponseEntity<String> response) {
+        return new Gson().fromJson(response.getBody(), FacebookAccessTokenDto.class)
+                .getAccessToken();
+    }
+
+    private FacebookUserInfoDto getFacebookUserInfo(String accessToken) {
+        HttpHeaders headers = getUserInfoHeaders(accessToken);
+        ResponseEntity<String> response = sendUserInfoRequest(headers);
+
+        if (isRequestFailed(response)) {
+            log.warn(
+                    "페이스북으로부터 유저 정보를 획득하지 못했습니다. 상태코드 {}: {}",
+                    response.getStatusCode(),
+                    response.getBody()
+            );
+            throw new RuntimeException("페이스북 유저 정보 획득 실패");
+        }
+
+        return getUserInfoFromResponse(response);
+    }
+
+    private HttpHeaders getUserInfoHeaders(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return headers;
+    }
+
+    private ResponseEntity<String> sendUserInfoRequest(HttpHeaders headers) {
+        HttpEntity<String> httpEntity = new HttpEntity<>(headers);
+
+        return new RestTemplate().exchange(USER_INFO_BASE_URL, HttpMethod.GET, httpEntity, String.class);
+    }
+
+    private boolean isRequestFailed(ResponseEntity<String> responseEntity) {
+        return !responseEntity.getStatusCode().is2xxSuccessful();
+    }
+
+    private FacebookUserInfoDto getUserInfoFromResponse(ResponseEntity<String> response) {
+        return new Gson().fromJson(response.getBody(), FacebookUserInfoDto.class);
+    }
+}

--- a/src/main/java/goodspace/backend/authorization/service/goodspace/GoodSpaceAuthorizationService.java
+++ b/src/main/java/goodspace/backend/authorization/service/goodspace/GoodSpaceAuthorizationService.java
@@ -1,15 +1,11 @@
-package goodspace.backend.authorization.service;
+package goodspace.backend.authorization.service.goodspace;
 
-import goodspace.backend.authorization.dto.request.AccessTokenReissueRequestDto;
 import goodspace.backend.authorization.dto.request.SignInRequestDto;
 import goodspace.backend.authorization.dto.request.SignUpRequestDto;
-import goodspace.backend.authorization.dto.response.AccessTokenResponseDto;
 import goodspace.backend.authorization.dto.response.TokenResponseDto;
 
 public interface GoodSpaceAuthorizationService {
     TokenResponseDto signUp(SignUpRequestDto requestDto);
 
     TokenResponseDto signIn(SignInRequestDto requestDto);
-
-    AccessTokenResponseDto reissueAccessToken(AccessTokenReissueRequestDto requestDto);
 }

--- a/src/main/java/goodspace/backend/authorization/service/goodspace/GoodSpaceAuthorizationServiceImpl.java
+++ b/src/main/java/goodspace/backend/authorization/service/goodspace/GoodSpaceAuthorizationServiceImpl.java
@@ -1,12 +1,9 @@
-package goodspace.backend.authorization.service;
+package goodspace.backend.authorization.service.goodspace;
 
-import goodspace.backend.authorization.dto.request.AccessTokenReissueRequestDto;
 import goodspace.backend.authorization.dto.request.SignInRequestDto;
 import goodspace.backend.authorization.dto.request.SignUpRequestDto;
-import goodspace.backend.authorization.dto.response.AccessTokenResponseDto;
 import goodspace.backend.authorization.dto.response.TokenResponseDto;
 import goodspace.backend.domain.user.GoodSpaceUser;
-import goodspace.backend.domain.user.User;
 import goodspace.backend.email.entity.EmailVerification;
 import goodspace.backend.email.repository.EmailVerificationRepository;
 import goodspace.backend.repository.UserRepository;
@@ -25,7 +22,6 @@ public class GoodSpaceAuthorizationServiceImpl implements GoodSpaceAuthorization
     private static final Supplier<EntityNotFoundException> VERIFICATION_NOT_FOUND = () -> new EntityNotFoundException("이메일 인증 정보가 없습니다.");
     private static final Supplier<IllegalStateException> NOT_VERIFIED = () -> new IllegalStateException("이메일이 인증되지 않았습니다.");
     private static final Supplier<EntityNotFoundException> USER_NOT_FOUND = () -> new EntityNotFoundException("회원을 찾을 수 없습니다.");
-    private static final Supplier<IllegalArgumentException> EXPIRED_TOKEN = () -> new IllegalArgumentException("만료된 토큰입니다.");
 
     private final UserRepository userRepository;
     private final EmailVerificationRepository emailVerificationRepository;
@@ -63,26 +59,6 @@ public class GoodSpaceAuthorizationServiceImpl implements GoodSpaceAuthorization
         return TokenResponseDto.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
-                .build();
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public AccessTokenResponseDto reissueAccessToken(AccessTokenReissueRequestDto requestDto) {
-        String refreshToken = requestDto.refreshToken();
-        long userId = tokenProvider.getIdFromToken(refreshToken);
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(USER_NOT_FOUND);
-
-        String existsRefreshToken = user.getRefreshToken();
-
-        if (!refreshToken.equals(existsRefreshToken)) {
-            throw EXPIRED_TOKEN.get();
-        }
-
-        return AccessTokenResponseDto.builder()
-                .accessToken(tokenProvider.createToken(userId, TokenType.ACCESS))
                 .build();
     }
 

--- a/src/main/java/goodspace/backend/authorization/service/google/GoogleOAuthService.java
+++ b/src/main/java/goodspace/backend/authorization/service/google/GoogleOAuthService.java
@@ -1,0 +1,166 @@
+package goodspace.backend.authorization.service.google;
+
+import com.google.gson.Gson;
+import goodspace.backend.authorization.dto.google.GoogleAccessTokenDto;
+import goodspace.backend.authorization.dto.google.GoogleUserInfoDto;
+import goodspace.backend.authorization.dto.response.TokenResponseDto;
+import goodspace.backend.authorization.service.OAuthService;
+import goodspace.backend.domain.user.User;
+import goodspace.backend.repository.UserRepository;
+import goodspace.backend.security.TokenProvider;
+import goodspace.backend.security.TokenType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.Map;
+
+import static goodspace.backend.domain.user.OAuthType.*;
+
+@Service
+@Slf4j
+public class GoogleOAuthService implements OAuthService {
+
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+
+    private final String TOKEN_BASE_URL = "https://oauth2.googleapis.com/token";
+    private final String USER_INFO_BASE_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
+    private final String OAUTH_PAGE_REDIRECT_BASE_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+    private final String SCOPE = "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email";
+    private final String CLIENT_ID;
+    private final String CLIENT_SECRET;
+    private final String REDIRECT_URI;
+
+    public GoogleOAuthService(
+            UserRepository userRepository,
+            TokenProvider tokenProvider,
+            @Value("${keys.google.client-id}") String clientId,
+            @Value("${keys.google.client-secret}") String clientSecret,
+            @Value("${keys.google.redirect-uri}") String redirectUri
+    ) {
+        this.userRepository = userRepository;
+        this.tokenProvider = tokenProvider;
+
+        this.CLIENT_ID = clientId;
+        this.CLIENT_SECRET = clientSecret;
+        this.REDIRECT_URI = redirectUri;
+    }
+
+    @Override
+    public String getAccessToken(String code) {
+        Map<String, String> params = getTokenParams(code);
+        ResponseEntity<String> response = sendTokenRequest(params);
+
+        if (isRequestFailed(response)) {
+            log.warn(
+                    "구글로부터 엑세스 토큰을 획득하지 못했습니다. 상태코드 {}: {}",
+                    response.getStatusCode(),
+                    response.getBody()
+            );
+            throw new RuntimeException("구글 엑세스 토큰 획득 실패");
+        }
+
+        return getAccessTokenFromResponse(response);
+    }
+
+    @Override
+    @Transactional
+    public TokenResponseDto signUpOrSignIn(String googleAccessToken) {
+        GoogleUserInfoDto googleUserInfo = getGoogleUserInfo(googleAccessToken);
+
+        User user = userRepository.findByIdentifierAndOAuthType(googleUserInfo.getId(), GOOGLE)
+                .orElseGet(() -> userRepository.save(googleUserInfo.toEntity()));
+
+        String accessTokenValue = tokenProvider.createToken(user.getId(), TokenType.ACCESS);
+        String refreshTokenValue = tokenProvider.createToken(user.getId(), TokenType.REFRESH);
+
+        user.updateRefreshToken(refreshTokenValue);
+
+        return new TokenResponseDto(accessTokenValue, refreshTokenValue);
+    }
+
+    @Override
+    public String getOauthPageRedirectUrl() {
+        return OAUTH_PAGE_REDIRECT_BASE_URL +
+                "?client_id=" + CLIENT_ID +
+                "&redirect_uri=" + REDIRECT_URI +
+                "&response_type=code" +
+                "&scope=" + SCOPE;
+    }
+
+    private Map<String, String> getTokenParams(String code) {
+        return Map.of(
+                "code", code,
+                "scope", SCOPE,
+                "client_id", CLIENT_ID,
+                "client_secret", CLIENT_SECRET,
+                "redirect_uri", REDIRECT_URI,
+                "grant_type", "authorization_code"
+        );
+    }
+
+    private ResponseEntity<String> sendTokenRequest(Map<String, String> params) {
+        return new RestTemplate()
+                .postForEntity(TOKEN_BASE_URL, params, String.class);
+    }
+
+    private String getAccessTokenFromResponse(ResponseEntity<String> responseEntity) {
+        String json = responseEntity.getBody();
+
+        return new Gson().fromJson(json, GoogleAccessTokenDto.class)
+                .getAccessToken();
+    }
+
+    private GoogleUserInfoDto getGoogleUserInfo(String accessToken) {
+        HttpHeaders headers = getUserInfoHeaders(accessToken);
+        String url = getUserInfoUrl(accessToken);
+
+        ResponseEntity<String> response = sendUserInfoRequest(headers, url);
+
+        if (isRequestFailed(response)) {
+            log.warn(
+                    "구글로부터 회원 정보를 획득하지 못했습니다. 상태코드 {}: {}",
+                    response.getStatusCode(),
+                    response.getBody()
+            );
+            throw new RuntimeException("구글 회원 정보 획득 실패");
+        }
+
+        return getUserInfoFromResponse(response);
+    }
+
+    private static ResponseEntity<String> sendUserInfoRequest(HttpHeaders headers, String url) {
+        RequestEntity<Void> requestEntity = new RequestEntity<>(headers, HttpMethod.GET, URI.create(url));
+
+        return new RestTemplate().exchange(requestEntity, String.class);
+    }
+
+    private HttpHeaders getUserInfoHeaders(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return headers;
+    }
+
+    private String getUserInfoUrl(String accessToken) {
+        return USER_INFO_BASE_URL +
+                "?access_token=" + accessToken;
+    }
+
+    private GoogleUserInfoDto getUserInfoFromResponse(ResponseEntity<String> responseEntity) {
+        String json = responseEntity.getBody();
+
+        return new Gson().fromJson(json, GoogleUserInfoDto.class);
+    }
+
+    private boolean isRequestFailed(ResponseEntity<String> responseEntity) {
+        return !responseEntity.getStatusCode().is2xxSuccessful();
+    }
+}

--- a/src/main/java/goodspace/backend/authorization/service/kakao/KaKaoOAuthService.java
+++ b/src/main/java/goodspace/backend/authorization/service/kakao/KaKaoOAuthService.java
@@ -1,0 +1,176 @@
+package goodspace.backend.authorization.service.kakao;
+
+import com.google.gson.Gson;
+import goodspace.backend.authorization.dto.kakao.KakaoAccessTokenDto;
+import goodspace.backend.authorization.dto.kakao.KakaoUserInfoDto;
+import goodspace.backend.authorization.dto.response.TokenResponseDto;
+import goodspace.backend.authorization.service.OAuthService;
+import goodspace.backend.domain.user.OAuthType;
+import goodspace.backend.domain.user.User;
+import goodspace.backend.repository.UserRepository;
+import goodspace.backend.security.TokenProvider;
+import goodspace.backend.security.TokenType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Slf4j
+public class KaKaoOAuthService implements OAuthService {
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+
+    private static final String TOKEN_BASE_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String USER_INFO_BASE_URL = "https://kapi.kakao.com/v2/user/me";
+    private static final String OAUTH_PAGE_REDIRECT_BASE_URL = "https://kauth.kakao.com/oauth/authorize";
+    private static final String SCOPE = "account_email";
+
+    private final String CLIENT_ID;
+    private final String CLIENT_SECRET;
+    private final String REDIRECT_URI;
+
+    public KaKaoOAuthService(
+            UserRepository userRepository,
+            TokenProvider tokenProvider,
+            @Value("${keys.kakao.rest-api-key}") String clientId,
+            @Value("${keys.kakao.client-secret}") String clientSecret,
+            @Value("${keys.kakao.redirect-uri}") String redirectUri
+    ) {
+        this.userRepository = userRepository;
+        this.tokenProvider = tokenProvider;
+
+        this.CLIENT_ID = clientId;
+        this.CLIENT_SECRET = clientSecret;
+        this.REDIRECT_URI = redirectUri;
+    }
+
+    @Override
+    public String getAccessToken(String code) {
+        HttpHeaders headers = getTokenHeaders();
+
+        LinkedMultiValueMap<String, String> params = getTokenParams(code);
+        ResponseEntity<String> response = sendTokenRequest(params, headers);
+
+        if (isRequestFailed(response)) {
+            log.warn(
+                    "카카오로부터 엑세스토큰을 획득하지 못했습니다. 상태코드 {}: {}",
+                    response.getStatusCode(),
+                    response.getBody()
+            );
+            throw new RuntimeException("카카오로부터 엑세스토큰을 획득하지 못했습니다.");
+        }
+
+        return getAccessTokenFromResponse(response);
+    }
+
+    @Override
+    @Transactional
+    public TokenResponseDto signUpOrSignIn(String kakaoAccessToken) {
+        KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(kakaoAccessToken);
+
+        if (!kakaoUserInfo.isValidatedEmail()) {
+            throw new IllegalStateException("이메일 인증이 되지 않은 유저입니다.");
+        }
+
+        User user = userRepository.findByIdentifierAndOAuthType(kakaoUserInfo.getId(), OAuthType.KAKAO)
+                .orElseGet(() -> userRepository.save(kakaoUserInfo.toEntity()));
+
+        String accessTokenValue = tokenProvider.createToken(user.getId(), TokenType.ACCESS);
+        String refreshTokenValue = tokenProvider.createToken(user.getId(), TokenType.REFRESH);
+        user.updateRefreshToken(refreshTokenValue);
+
+        return new TokenResponseDto(accessTokenValue, refreshTokenValue);
+    }
+
+    @Override
+    public String getOauthPageRedirectUrl() {
+        return OAUTH_PAGE_REDIRECT_BASE_URL +
+                "?client_id=" + CLIENT_ID +
+                "&redirect_uri=" + REDIRECT_URI +
+                "&response_type=code" +
+                "&scope=" + SCOPE;
+    }
+
+    private HttpHeaders getTokenHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        return headers;
+    }
+
+    private LinkedMultiValueMap<String, String> getTokenParams(String code) {
+        LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+        params.add("code", code);
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", CLIENT_ID);
+        params.add("redirect_uri", REDIRECT_URI);
+        params.add("client_secret", CLIENT_SECRET);
+
+        return params;
+    }
+
+    private ResponseEntity<String> sendTokenRequest(LinkedMultiValueMap<String, String> params, HttpHeaders headers) {
+        HttpEntity<MultiValueMap<String, String>> httpEntity = new HttpEntity<>(params, headers);
+
+        return new RestTemplate().exchange(TOKEN_BASE_URL, HttpMethod.POST, httpEntity, String.class);
+    }
+
+    private String getAccessTokenFromResponse(ResponseEntity<String> responseEntity) {
+        String json = responseEntity.getBody();
+
+        return new Gson().fromJson(json, KakaoAccessTokenDto.class)
+                .getAccessToken();
+    }
+
+    private KakaoUserInfoDto getKakaoUserInfo(String accessToken) {
+        HttpHeaders headers = getUserInfoHeaders(accessToken);
+
+        ResponseEntity<String> response = sendUserInfoRequest(headers);
+
+        if (isRequestFailed(response)) {
+            log.warn(
+                    "카카오로부터 유저 정보를 획득하지 못했습니다. 상태코드 {}: {}",
+                    response.getStatusCode(),
+                    response.getBody()
+            );
+            throw new RuntimeException("카카오로부터 유저 정보를 획득하지 못했습니다.");
+        }
+
+        return getUserInfoFromResponse(response);
+    }
+
+    private HttpHeaders getUserInfoHeaders(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.set("Authorization", "Bearer " + accessToken);
+        headers.set("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        return headers;
+    }
+
+    private ResponseEntity<String> sendUserInfoRequest(HttpHeaders headers) {
+        HttpEntity<String> httpEntity = new HttpEntity<>(headers);
+
+        return new RestTemplate().exchange(USER_INFO_BASE_URL, HttpMethod.GET, httpEntity, String.class);
+    }
+
+    private boolean isRequestFailed(ResponseEntity<String> responseEntity) {
+        return !responseEntity.getStatusCode().is2xxSuccessful();
+    }
+
+    private KakaoUserInfoDto getUserInfoFromResponse(ResponseEntity<String> responseEntity) {
+        String json = responseEntity.getBody();
+        Gson gson = new Gson();
+        return gson.fromJson(json, KakaoUserInfoDto.class);
+    }
+}

--- a/src/main/java/goodspace/backend/authorization/service/naver/NaverOAuthService.java
+++ b/src/main/java/goodspace/backend/authorization/service/naver/NaverOAuthService.java
@@ -1,0 +1,154 @@
+package goodspace.backend.authorization.service.naver;
+
+import com.google.gson.Gson;
+import goodspace.backend.authorization.dto.naver.NaverAccessTokenDto;
+import goodspace.backend.authorization.dto.naver.NaverUserInfoDto;
+import goodspace.backend.authorization.dto.response.TokenResponseDto;
+import goodspace.backend.authorization.service.OAuthService;
+import goodspace.backend.domain.user.User;
+import goodspace.backend.repository.UserRepository;
+import goodspace.backend.security.TokenProvider;
+import goodspace.backend.security.TokenType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import static goodspace.backend.domain.user.OAuthType.NAVER;
+
+@Service
+@Slf4j
+public class NaverOAuthService implements OAuthService {
+
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+
+    private static final String TOKEN_BASE_URL = "https://nid.naver.com/oauth2.0/token";
+    private static final String USER_INFO_BASE_URL = "https://openapi.naver.com/v1/nid/me";
+    private static final String OAUTH_PAGE_REDIRECTION_BASE_URL = "https://nid.naver.com/oauth2.0/authorize";
+    private static final String SCOPE = "email";
+
+    private final String CLIENT_ID;
+    private final String CLIENT_SECRET;
+    private final String REDIRECT_URI;
+
+    public NaverOAuthService(
+            UserRepository userRepository,
+            TokenProvider tokenProvider,
+            @Value("${keys.naver.client-id}") String clientId,
+            @Value("${keys.naver.client-secret}") String clientSecret,
+            @Value("${keys.naver.redirect-uri}") String redirectUri
+    ) {
+        this.userRepository = userRepository;
+        this.tokenProvider = tokenProvider;
+        this.CLIENT_ID = clientId;
+        this.CLIENT_SECRET = clientSecret;
+        this.REDIRECT_URI = redirectUri;
+    }
+
+    @Override
+    public String getAccessToken(String code) {
+        HttpHeaders headers = getTokenHeaders();
+        MultiValueMap<String, String> params = getTokenParams(code);
+
+        ResponseEntity<String> response = sendTokenRequest(params, headers);
+
+        if (isRequestFailed(response)) {
+            log.warn(
+                    "네이버로부터 엑세스토큰을 획득하지 못했습니다. 상태코드 {}: {}",
+                    response.getStatusCode(),
+                    response.getBody()
+            );
+            throw new RuntimeException("네이버로부터 엑세스토큰을 획득하지 못했습니다.");
+        }
+
+        return getTokenFromResponse(response);
+    }
+
+    @Override
+    @Transactional
+    public TokenResponseDto signUpOrSignIn(String naverAccessToken) {
+        NaverUserInfoDto naverUserInfo = getNaverUserInfo(naverAccessToken);
+
+        User user = userRepository.findByIdentifierAndOAuthType(naverUserInfo.getId(), NAVER)
+                .orElseGet(() -> userRepository.save(naverUserInfo.toEntity()));
+
+        String accessTokenValue = tokenProvider.createToken(user.getId(), TokenType.ACCESS);
+        String refreshTokenValue = tokenProvider.createToken(user.getId(), TokenType.REFRESH);
+        user.updateRefreshToken(refreshTokenValue);
+
+        return new TokenResponseDto(accessTokenValue, refreshTokenValue);
+    }
+
+    @Override
+    public String getOauthPageRedirectUrl() {
+        return OAUTH_PAGE_REDIRECTION_BASE_URL +
+                "?client_id=" + CLIENT_ID +
+                "&redirect_uri=" + REDIRECT_URI +
+                "&response_type=code" +
+                "&scope=" + SCOPE;
+    }
+
+    private HttpHeaders getTokenHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        return headers;
+    }
+
+    private MultiValueMap<String, String> getTokenParams(String code) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", CLIENT_ID);
+        params.add("client_secret", CLIENT_SECRET);
+        params.add("code", code);
+        params.add("redirect_uri", REDIRECT_URI);
+
+        return params;
+    }
+
+    private ResponseEntity<String> sendTokenRequest(MultiValueMap<String, String> params, HttpHeaders headers) {
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        return new RestTemplate().exchange(TOKEN_BASE_URL, HttpMethod.POST, request, String.class);
+    }
+
+    private String getTokenFromResponse(ResponseEntity<String> response) {
+        return new Gson().fromJson(response.getBody(), NaverAccessTokenDto.class)
+                .getAccessToken();
+    }
+
+    private NaverUserInfoDto getNaverUserInfo(String accessToken) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        ResponseEntity<String> response = restTemplate.exchange(USER_INFO_BASE_URL, HttpMethod.GET, entity, String.class);
+
+        if (isRequestFailed(response)) {
+            log.warn(
+                    "네이버로부터 회원 정보를 획득하지 못했습니다. 상태코드 {}: {}",
+                    response.getStatusCode(),
+                    response.getBody()
+            );
+            throw new RuntimeException("네이버로부터 회원 정보를 획득하지 못했습니다.");
+        }
+
+        return getUserInfoFromResponse(response);
+    }
+
+    private NaverUserInfoDto getUserInfoFromResponse(ResponseEntity<String> response) {
+        return new Gson().fromJson(response.getBody(), NaverUserInfoDto.class);
+    }
+
+    private boolean isRequestFailed(ResponseEntity<String> response) {
+        return !response.getStatusCode().is2xxSuccessful();
+    }
+}

--- a/src/main/java/goodspace/backend/domain/user/AppleUser.java
+++ b/src/main/java/goodspace/backend/domain/user/AppleUser.java
@@ -1,8 +1,0 @@
-package goodspace.backend.domain.user;
-
-import jakarta.persistence.Entity;
-
-@Entity
-public class AppleUser extends User {
-    private String identifier;
-}

--- a/src/main/java/goodspace/backend/domain/user/GoogleUser.java
+++ b/src/main/java/goodspace/backend/domain/user/GoogleUser.java
@@ -1,8 +1,0 @@
-package goodspace.backend.domain.user;
-
-import jakarta.persistence.Entity;
-
-@Entity
-public class GoogleUser extends User {
-    private String identifier;
-}

--- a/src/main/java/goodspace/backend/domain/user/KakaoUser.java
+++ b/src/main/java/goodspace/backend/domain/user/KakaoUser.java
@@ -1,8 +1,0 @@
-package goodspace.backend.domain.user;
-
-import jakarta.persistence.Entity;
-
-@Entity
-public class KakaoUser extends User {
-    private String identifier;
-}

--- a/src/main/java/goodspace/backend/domain/user/NaverUser.java
+++ b/src/main/java/goodspace/backend/domain/user/NaverUser.java
@@ -1,8 +1,0 @@
-package goodspace.backend.domain.user;
-
-import jakarta.persistence.Entity;
-
-@Entity
-public class NaverUser extends User {
-    private String identifier;
-}

--- a/src/main/java/goodspace/backend/domain/user/OAuthType.java
+++ b/src/main/java/goodspace/backend/domain/user/OAuthType.java
@@ -1,0 +1,5 @@
+package goodspace.backend.domain.user;
+
+public enum OAuthType {
+    GOOD_SPACE, APPLE, FACEBOOK, GOOGLE, KAKAO, NAVER
+}

--- a/src/main/java/goodspace/backend/domain/user/OAuthUser.java
+++ b/src/main/java/goodspace/backend/domain/user/OAuthUser.java
@@ -1,0 +1,17 @@
+package goodspace.backend.domain.user;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OAuthUser extends User {
+    private String identifier;
+    @Enumerated
+    private OAuthType oauthType;
+}

--- a/src/main/java/goodspace/backend/domain/user/OAuthUser.java
+++ b/src/main/java/goodspace/backend/domain/user/OAuthUser.java
@@ -1,7 +1,6 @@
 package goodspace.backend.domain.user;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Enumerated;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -10,7 +9,16 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "oauth_user_uq_identifier_oauth_type",
+                        columnNames = {"identifier", "oauth_type"}
+                )
+        }
+)
 public class OAuthUser extends User {
+    @Column(nullable = false)
     private String identifier;
     @Enumerated
     private OAuthType oauthType;

--- a/src/main/java/goodspace/backend/domain/user/User.java
+++ b/src/main/java/goodspace/backend/domain/user/User.java
@@ -5,9 +5,7 @@ import goodspace.backend.domain.Order;
 import goodspace.backend.security.RefreshToken;
 import goodspace.backend.dto.UserMyPageDto;
 import jakarta.persistence.*;
-import lombok.*;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -20,7 +18,7 @@ import java.util.List;
 @SuperBuilder
 @Getter
 @AllArgsConstructor
-public class User extends BaseEntity {
+public abstract class User extends BaseEntity {
     @Id
     @GeneratedValue
     private Long id;

--- a/src/main/java/goodspace/backend/repository/UserRepository.java
+++ b/src/main/java/goodspace/backend/repository/UserRepository.java
@@ -1,16 +1,24 @@
 package goodspace.backend.repository;
 
 import goodspace.backend.domain.user.GoodSpaceUser;
+import goodspace.backend.domain.user.OAuthType;
+import goodspace.backend.domain.user.OAuthUser;
 import goodspace.backend.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.Optional;
 
-@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+
     @Query("SELECT u FROM GoodSpaceUser u WHERE u.email = :email AND u.password = :password")
     Optional<GoodSpaceUser> findByEmailAndPassword(String email, String password);
 
-    Optional<User> findByEmail(String email);
+    @Query("SELECT u FROM OAuthUser u WHERE u.identifier = :identifier AND u.oauthType = :oauthType")
+    Optional<OAuthUser> findByIdentifierAndOAuthType(
+            @Param("identifier") String identifier,
+            @Param("oauthType") OAuthType oauthType
+    );
 }

--- a/src/test/java/goodspace/backend/authorization/service/AccessTokenServiceTest.java
+++ b/src/test/java/goodspace/backend/authorization/service/AccessTokenServiceTest.java
@@ -1,0 +1,85 @@
+package goodspace.backend.authorization.service;
+
+import goodspace.backend.authorization.dto.request.AccessTokenReissueRequestDto;
+import goodspace.backend.authorization.dto.response.AccessTokenResponseDto;
+import goodspace.backend.domain.user.GoodSpaceUser;
+import goodspace.backend.fixture.GoodSpaceUserFixture;
+import goodspace.backend.repository.UserRepository;
+import goodspace.backend.security.TokenProvider;
+import goodspace.backend.security.TokenType;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+class AccessTokenServiceTest {
+    private final SecureRandom random = new SecureRandom();
+
+    private final AccessTokenService accessTokenService;
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+
+    private GoodSpaceUser existUser;
+
+    @BeforeEach
+    void resetEntity() {
+        existUser = createEntityFromFixture(GoodSpaceUserFixture.DEFAULT);
+    }
+
+    @Nested
+    class reissueAccessToken {
+        @Test
+        @DisplayName("전달한 토큰이 저장된 리프레쉬 토큰과 일치하면 엑세스 토큰을 발급한다")
+        void ifRefreshTokenIsLegalThenIssueAccessToken() {
+            // given
+            String refreshToken = existUser.getRefreshToken();
+
+            // when
+            AccessTokenResponseDto responseDto = accessTokenService.reissue(new AccessTokenReissueRequestDto(refreshToken));
+
+            // then
+            String accessToken = responseDto.accessToken();
+            boolean isLegalAccessToken = tokenProvider.validateToken(accessToken, TokenType.ACCESS);
+
+            assertThat(isLegalAccessToken).isTrue();
+        }
+
+        @Test
+        @DisplayName("저장된 리프레쉬 토큰과 일치하지 않으면 예외를 던진다")
+        void ifIllegalRefreshTokenThenThrowException() throws InterruptedException {
+            String differentRefreshToken = getDifferentRefreshToken(existUser.getId());
+
+            assertThatThrownBy(() -> accessTokenService.reissue(new AccessTokenReissueRequestDto(differentRefreshToken)))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    private GoodSpaceUser createEntityFromFixture(GoodSpaceUserFixture fixture) {
+        GoodSpaceUser user = fixture.getInstance();
+        userRepository.save(user);
+
+        String refreshToken = tokenProvider.createToken(user.getId(), TokenType.REFRESH);
+        user.updateRefreshToken(refreshToken);
+
+        return (GoodSpaceUser) userRepository.findById(user.getId())
+                .orElseThrow();
+    }
+
+    private String getDifferentRefreshToken(long userId) throws InterruptedException {
+        Thread.sleep(1000);
+
+        return tokenProvider.createToken(userId, TokenType.REFRESH);
+    }
+}

--- a/src/test/java/goodspace/backend/authorization/service/goodspace/GoodSpaceAuthorizationServiceTest.java
+++ b/src/test/java/goodspace/backend/authorization/service/goodspace/GoodSpaceAuthorizationServiceTest.java
@@ -1,9 +1,7 @@
-package goodspace.backend.authorization.service;
+package goodspace.backend.authorization.service.goodspace;
 
-import goodspace.backend.authorization.dto.request.AccessTokenReissueRequestDto;
 import goodspace.backend.authorization.dto.request.SignInRequestDto;
 import goodspace.backend.authorization.dto.request.SignUpRequestDto;
-import goodspace.backend.authorization.dto.response.AccessTokenResponseDto;
 import goodspace.backend.authorization.dto.response.TokenResponseDto;
 import goodspace.backend.domain.user.GoodSpaceUser;
 import goodspace.backend.email.entity.EmailVerification;
@@ -22,8 +20,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.security.SecureRandom;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -33,8 +29,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class GoodSpaceAuthorizationServiceTest {
     private static final int SLEEP_FOR_GET_DIFFERENT_TOKEN = 1000;
     private static final String DEFAULT_PASSWORD = "defaultPassword!";
-
-    private final SecureRandom random = new SecureRandom();
 
     private final GoodSpaceAuthorizationService authorizationService;
     private final EmailVerificationRepository emailVerificationRepository;
@@ -152,34 +146,6 @@ class GoodSpaceAuthorizationServiceTest {
         }
     }
 
-    @Nested
-    class reissueAccessToken {
-        @Test
-        @DisplayName("전달한 토큰이 저장된 리프레쉬 토큰과 일치하면 엑세스 토큰을 발급한다")
-        void ifRefreshTokenIsLegalThenIssueAccessToken() {
-            // given
-            String refreshToken = existUser.getRefreshToken();
-
-            // when
-            AccessTokenResponseDto responseDto = authorizationService.reissueAccessToken(new AccessTokenReissueRequestDto(refreshToken));
-
-            // then
-            String accessToken = responseDto.accessToken();
-            boolean isLegalAccessToken = tokenProvider.validateToken(accessToken, TokenType.ACCESS);
-
-            assertThat(isLegalAccessToken).isTrue();
-        }
-
-        @Test
-        @DisplayName("저장된 리프레쉬 토큰과 일치하지 않으면 예외를 던진다")
-        void ifIllegalRefreshTokenThenThrowException() {
-            String differentRefreshToken = getDifferentRefreshToken(existUser.getRefreshToken());
-
-            assertThatThrownBy(() -> authorizationService.reissueAccessToken(new AccessTokenReissueRequestDto(differentRefreshToken)))
-                    .isInstanceOf(IllegalArgumentException.class);
-        }
-    }
-
     private EmailVerification createEntityFromFixture(EmailVerificationFixture fixture) {
         EmailVerification instance = fixture.getInstance();
         emailVerificationRepository.save(instance);
@@ -197,16 +163,5 @@ class GoodSpaceAuthorizationServiceTest {
 
         return (GoodSpaceUser) userRepository.findById(user.getId())
                 .orElseThrow();
-    }
-
-    private String getDifferentRefreshToken(String originalRefreshToken) {
-        String refreshToken = "";
-
-        while (refreshToken.equals(originalRefreshToken)) {
-            int randomUserId = random.nextInt();
-            refreshToken = tokenProvider.createToken(randomUserId, TokenType.REFRESH);
-        }
-
-        return refreshToken;
     }
 }

--- a/src/test/java/goodspace/backend/email/LocalEmailTest.java
+++ b/src/test/java/goodspace/backend/email/LocalEmailTest.java
@@ -52,7 +52,6 @@ class LocalEmailTest {
 
         mailSender.send(message);
 
-        // 3) GreenMail 에 수신된 메시지 검증
         MimeMessage[] received = greenMail.getReceivedMessages();
         assertThat(received).hasSize(1);
 


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
- Naver, Google, Kakao, Facebook에 대한 OAuth를 구현했습니다.
- `User`의 자식 클래스들을 `GoodSpaceUser`와 `OAuthUser`로 통합했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#22 

## 📝 참고할 사항
- Apple OAuth를 사용하기 위해선 Apple Developers 연회비를 내야 해서 이후로 미루겠습니다.
- 외부 API를 사용하는 서비스 클래스는 테스트 코드를 작성하지 않았습니다.

## 🎯 코드 리뷰 시 중점적으로 보면 좋은 내용
