### PR TITLE
[feat/#26] 클라이언트 조회 API 구현

### DIFF
--- a/src/main/java/goodspace/backend/client/controller/ClientController.java
+++ b/src/main/java/goodspace/backend/client/controller/ClientController.java
@@ -1,0 +1,48 @@
+package goodspace.backend.client.controller;
+
+import goodspace.backend.client.dto.ClientBriefInfoResponseDto;
+import goodspace.backend.client.dto.ClientDetailsResponseDto;
+import goodspace.backend.client.service.ClientService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/client")
+@Tag(
+        name = "클라이언트 API",
+        description = "클라이언트 정보 및 굿즈 정보 관련 기능"
+)
+public class ClientController {
+    private final ClientService clientService;
+
+    @GetMapping
+    @Operation(
+            summary = "클라이언트 목록 조회",
+            description = "모든 클라이언트에 대한 간략한 정보를 반환합니다"
+    )
+    public ResponseEntity<List<ClientBriefInfoResponseDto>> findClients() {
+        List<ClientBriefInfoResponseDto> responseDto = clientService.getClients();
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/{clientId}")
+    @Operation(
+            summary = "클라이언트 조회",
+            description = "식별자와 일치하는 클라이언트의 정보를 반환합니다(랜딩 페이지 용도)"
+    )
+    public ResponseEntity<ClientDetailsResponseDto> findClientDetails(@PathVariable long clientId) {
+        ClientDetailsResponseDto responseDto = clientService.getDetails(clientId);
+
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/src/main/java/goodspace/backend/client/dto/ClientBriefInfoResponseDto.java
+++ b/src/main/java/goodspace/backend/client/dto/ClientBriefInfoResponseDto.java
@@ -1,0 +1,22 @@
+package goodspace.backend.client.dto;
+
+import goodspace.backend.domain.client.Client;
+import goodspace.backend.domain.client.ClientType;
+import lombok.Builder;
+
+@Builder
+public record ClientBriefInfoResponseDto(
+        Long id,
+        String name,
+        String profileImageUrl,
+        ClientType clientType
+) {
+    public static ClientBriefInfoResponseDto from(Client client) {
+        return ClientBriefInfoResponseDto.builder()
+                .id(client.getId())
+                .name(client.getName())
+                .profileImageUrl(client.getProfileImageUrl())
+                .clientType(client.getClientType())
+                .build();
+    }
+}

--- a/src/main/java/goodspace/backend/client/dto/ClientDetailsResponseDto.java
+++ b/src/main/java/goodspace/backend/client/dto/ClientDetailsResponseDto.java
@@ -1,0 +1,29 @@
+package goodspace.backend.client.dto;
+
+import goodspace.backend.domain.client.Client;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ClientDetailsResponseDto(
+        String name,
+        String profileImageUrl,
+        String backgroundImageUrl,
+        String introduction,
+        List<ItemBriefInfoResponseDto> items
+) {
+    public static ClientDetailsResponseDto from(Client client) {
+        List<ItemBriefInfoResponseDto> items = client.getItems().stream()
+                .map(ItemBriefInfoResponseDto::from)
+                .toList();
+
+        return ClientDetailsResponseDto.builder()
+                .name(client.getName())
+                .profileImageUrl(client.getProfileImageUrl())
+                .backgroundImageUrl(client.getBackgroundImageUrl())
+                .introduction(client.getIntroduction())
+                .items(items)
+                .build();
+    }
+}

--- a/src/main/java/goodspace/backend/client/dto/ItemBriefInfoResponseDto.java
+++ b/src/main/java/goodspace/backend/client/dto/ItemBriefInfoResponseDto.java
@@ -1,0 +1,21 @@
+package goodspace.backend.client.dto;
+
+import goodspace.backend.domain.client.Item;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ItemBriefInfoResponseDto(
+        String name,
+        String landingPageDescription,
+        List<String> imageUrls
+) {
+    public static ItemBriefInfoResponseDto from(Item item) {
+        return ItemBriefInfoResponseDto.builder()
+                .name(item.getName())
+                .landingPageDescription(item.getLandingPageDescription())
+                .imageUrls(item.getImageUrls())
+                .build();
+    }
+}

--- a/src/main/java/goodspace/backend/client/service/ClientService.java
+++ b/src/main/java/goodspace/backend/client/service/ClientService.java
@@ -1,0 +1,12 @@
+package goodspace.backend.client.service;
+
+import goodspace.backend.client.dto.ClientBriefInfoResponseDto;
+import goodspace.backend.client.dto.ClientDetailsResponseDto;
+
+import java.util.List;
+
+public interface ClientService {
+    ClientDetailsResponseDto getDetails(long clientId);
+
+    List<ClientBriefInfoResponseDto> getClients();
+}

--- a/src/main/java/goodspace/backend/client/service/ClientServiceImpl.java
+++ b/src/main/java/goodspace/backend/client/service/ClientServiceImpl.java
@@ -1,0 +1,37 @@
+package goodspace.backend.client.service;
+
+import goodspace.backend.client.dto.ClientBriefInfoResponseDto;
+import goodspace.backend.client.dto.ClientDetailsResponseDto;
+import goodspace.backend.domain.client.Client;
+import goodspace.backend.repository.ClientRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+@Service
+@RequiredArgsConstructor
+public class ClientServiceImpl implements ClientService {
+    private static final Supplier<EntityNotFoundException> CLIENT_NOT_FOUND = () -> new EntityNotFoundException("클라이언트를 찾지 못했습니다.");
+
+    private final ClientRepository clientRepository;
+
+    @Override
+    public ClientDetailsResponseDto getDetails(long clientId) {
+        Client client = clientRepository.findById(clientId)
+                .orElseThrow(CLIENT_NOT_FOUND);
+
+        return ClientDetailsResponseDto.from(client);
+    }
+
+    @Override
+    public List<ClientBriefInfoResponseDto> getClients() {
+        List<Client> clients = clientRepository.findAll();
+
+        return clients.stream()
+                .map(ClientBriefInfoResponseDto::from)
+                .toList();
+    }
+}

--- a/src/main/java/goodspace/backend/domain/client/Client.java
+++ b/src/main/java/goodspace/backend/domain/client/Client.java
@@ -5,19 +5,39 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Client extends BaseEntity {
     @Id
     @GeneratedValue
     private Long id;
     private String name;
     private String profileImageUrl;
-    private byte[] backgrountImage;
+    private String backgroundImageUrl;
     private String introduction;
+    private ClientType clientType;
 
     @OneToMany(mappedBy = "client")
-    private List<Item> items;
+    @Builder.Default
+    private final List<Item> items = new ArrayList<>();
+
+    /**
+     * Client - Item 연관관계 편의 메서드
+     */
+    public void addItem(Item item) {
+        items.add(item);
+        item.setClient(this);
+    }
 }

--- a/src/main/java/goodspace/backend/domain/client/ClientType.java
+++ b/src/main/java/goodspace/backend/domain/client/ClientType.java
@@ -1,0 +1,5 @@
+package goodspace.backend.domain.client;
+
+public enum ClientType {
+    CREATOR, INFLUENCER
+}

--- a/src/main/java/goodspace/backend/domain/client/Item.java
+++ b/src/main/java/goodspace/backend/domain/client/Item.java
@@ -2,29 +2,52 @@ package goodspace.backend.domain.client;
 
 import goodspace.backend.domain.BaseEntity;
 import goodspace.backend.domain.Order;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
+@Getter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Item extends BaseEntity {
     @Id
     private Long id;
     private String name;
     private Integer price;
     private String shortDescription;
-    private String randingPageDescription;
-
+    private String landingPageDescription;
 
     @ManyToOne
     @JoinColumn(name = "client_id")
+    @Setter
     private Client client;
 
     @ManyToOne
     @JoinColumn(name = "order_id")
     private Order order;
 
+    @OneToMany(mappedBy = "item")
+    @Builder.Default
+    private final List<ItemImage> itemImages = new ArrayList<>();
 
+    public List<String> getImageUrls() {
+        return itemImages.stream()
+                .map(ItemImage::getImageUrl)
+                .toList();
+    }
 
+    /**
+     * Item - ItemImage 연관관계 편의 메서드
+     */
+    public void addItemImages(List<ItemImage> itemImages) {
+        for (ItemImage itemImage : itemImages) {
+            this.itemImages.add(itemImage);
+            itemImage.setItem(this);
+        }
+    }
 }

--- a/src/main/java/goodspace/backend/domain/client/ItemImage.java
+++ b/src/main/java/goodspace/backend/domain/client/ItemImage.java
@@ -2,8 +2,17 @@ package goodspace.backend.domain.client;
 
 import goodspace.backend.domain.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
 
 @Entity
+@Getter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
 public class ItemImage extends BaseEntity {
     @Id
     @GeneratedValue
@@ -12,5 +21,6 @@ public class ItemImage extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "item_id")
+    @Setter
     private Item item;
 }

--- a/src/main/java/goodspace/backend/repository/ClientRepository.java
+++ b/src/main/java/goodspace/backend/repository/ClientRepository.java
@@ -1,0 +1,7 @@
+package goodspace.backend.repository;
+
+import goodspace.backend.domain.client.Client;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClientRepository extends JpaRepository<Client, Long> {
+}

--- a/src/main/java/goodspace/backend/security/SecurityConfig.java
+++ b/src/main/java/goodspace/backend/security/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**").permitAll() // swagger
                         .requestMatchers("/v3/api-docs/**").permitAll() // SpringDoc
                         .requestMatchers("/postalcode", "/css/**", "/js/**", "/images/**", "/stylesheets/**","/api/**").permitAll() // 우편번호 html허용
+                        .requestMatchers("/client/**").permitAll() // 클라이언트 상품 페이지 관련
                         .anyRequest().authenticated()
                 )
                 .cors(cors -> cors.configurationSource(configurationSource()))

--- a/src/test/java/goodspace/backend/client/service/ClientServiceTest.java
+++ b/src/test/java/goodspace/backend/client/service/ClientServiceTest.java
@@ -1,0 +1,126 @@
+package goodspace.backend.client.service;
+
+import goodspace.backend.client.dto.ClientBriefInfoResponseDto;
+import goodspace.backend.client.dto.ClientDetailsResponseDto;
+import goodspace.backend.client.dto.ItemBriefInfoResponseDto;
+import goodspace.backend.domain.client.Client;
+import goodspace.backend.domain.client.Item;
+import goodspace.backend.fixture.ClientFixture;
+import goodspace.backend.fixture.ItemFixture;
+import goodspace.backend.repository.ClientRepository;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+@Transactional
+class ClientServiceTest {
+    private final ClientService clientService;
+    private final ClientRepository clientRepository;
+
+    private Client clientA;
+    private Client clientB;
+    private Set<Client> clients;
+    
+    @BeforeEach
+    void resetEntities() {
+        Client client1 = ClientFixture.INFLUENCER.getInstance();
+        Item item1 = ItemFixture.A.getInstance();
+        client1.addItem(item1);
+
+        Client client2 = ClientFixture.CREATOR.getInstance();
+        Item item2 = ItemFixture.B.getInstance();
+        client1.addItem(item2);
+
+        this.clientA = clientRepository.save(client1);
+        this.clientB = clientRepository.save(client2);
+        this.clients = Set.of(clientA, clientB);
+    }
+
+    @Nested
+    class getDetails {
+        @Test
+        @DisplayName("클라이언트의 상세 정보를 반환한다")
+        void returnDetailsOfClient() {
+            ClientDetailsResponseDto details = clientService.getDetails(clientA.getId());
+
+            assertThat(isEqual(clientA, details)).isTrue();
+        }
+    }
+
+    @Nested
+    class getClients {
+        @Test
+        @DisplayName("클라이언트의 목록을 반환한다")
+        void returnClients() {
+            List<ClientBriefInfoResponseDto> clientDtos = clientService.getClients();
+
+            assertThat(clientDtos.size() == clients.size()).isTrue();
+
+            for (Client client : clients) {
+                ClientBriefInfoResponseDto clientDto = clientDtos.stream()
+                        .filter(dto -> dto.id().equals(client.getId()))
+                        .findAny()
+                        .orElseThrow(() -> new IllegalStateException("클라이언트와 아이디가 일치하는 DTO가 존재하지 않음"));
+
+                assertThat(isEqual(client, clientDto)).isTrue();
+            }
+        }
+    }
+
+    private boolean isEqual(Client client, ClientDetailsResponseDto dto) {
+        return client.getName().equals(dto.name()) &&
+                client.getProfileImageUrl().equals(dto.profileImageUrl()) &&
+                client.getBackgroundImageUrl().equals(dto.backgroundImageUrl()) &&
+                client.getIntroduction().equals(dto.introduction()) &&
+                isEqual(client.getItems(), dto.items());
+    }
+
+    private boolean isEqual(List<Item> items, List<ItemBriefInfoResponseDto> dtos) {
+        Set<String> itemNameSet = toSet(items, Item::getName);
+        Set<String> dtoNameSet = toSet(dtos, ItemBriefInfoResponseDto::name);
+
+        Set<String> itemDescriptionSet = toSet(items, Item::getLandingPageDescription);
+        Set<String> dtoDescriptionSet = toSet(dtos, ItemBriefInfoResponseDto::landingPageDescription);
+
+        Set<String> itemUrlSet = items.stream()
+                .map(Item::getImageUrls)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+        Set<String> dtoUrlSet = dtos.stream()
+                .map(ItemBriefInfoResponseDto::imageUrls)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+
+        return itemNameSet.equals(dtoNameSet) &&
+                itemDescriptionSet.equals(dtoDescriptionSet) &&
+                itemUrlSet.equals(dtoUrlSet);
+    }
+
+    private boolean isEqual(Client client, ClientBriefInfoResponseDto dto) {
+        return client.getId().equals(dto.id()) &&
+                client.getName().equals(dto.name()) &&
+                client.getProfileImageUrl().equals(dto.profileImageUrl()) &&
+                client.getClientType() == dto.clientType();
+    }
+
+    private <E, T> Set<T> toSet(List<E> list, Function<E, T> function) {
+        return list.stream()
+                .map(function)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/test/java/goodspace/backend/fixture/ClientFixture.java
+++ b/src/test/java/goodspace/backend/fixture/ClientFixture.java
@@ -1,0 +1,51 @@
+package goodspace.backend.fixture;
+
+import goodspace.backend.domain.client.Client;
+import goodspace.backend.domain.client.ClientType;
+
+public enum ClientFixture {
+    INFLUENCER(
+            "INFLUENCER KIM",
+            "http://influencer-kim-profile",
+            "http://influencer-kim-bg",
+            "Hello, I'm Influencer Kim!",
+            ClientType.INFLUENCER
+    ),
+    CREATOR(
+            "CREATOR PARK",
+            "http://creator-park-profile",
+            "http://creator-park-bg",
+            "Hello, I'm Creator Park!",
+            ClientType.CREATOR
+    );
+
+    private final String name;
+    private final String profileImageUrl;
+    private final String backgroundImageUrl;
+    private final String introduction;
+    private final ClientType clientType;
+
+    ClientFixture(
+            String name,
+            String profileImageUrl,
+            String backgroundImageUrl,
+            String introduction,
+            ClientType clientType
+    ) {
+        this.name = name;
+        this.profileImageUrl = profileImageUrl;
+        this.backgroundImageUrl = backgroundImageUrl;
+        this.introduction = introduction;
+        this.clientType = clientType;
+    }
+
+    public Client getInstance() {
+        return Client.builder()
+                .name(name)
+                .profileImageUrl(profileImageUrl)
+                .backgroundImageUrl(backgroundImageUrl)
+                .introduction(introduction)
+                .clientType(clientType)
+                .build();
+    }
+}

--- a/src/test/java/goodspace/backend/fixture/ItemFixture.java
+++ b/src/test/java/goodspace/backend/fixture/ItemFixture.java
@@ -1,0 +1,73 @@
+package goodspace.backend.fixture;
+
+import goodspace.backend.domain.client.Item;
+import goodspace.backend.domain.client.ItemImage;
+
+import java.util.List;
+
+public enum ItemFixture {
+    A(
+            "ITEM_A",
+            15000,
+            "short description of Item A",
+            "landing page description of Item A",
+            List.of("http://item-a-image-1", "http://item-a-image-2")
+    ),
+    B(
+            "ITEM_B",
+            20000,
+            "short description of Item B",
+            "landing page description of Item B",
+            List.of("http://item-b-image-1", "http://item-b-image-2", "http://item-b-image-3")
+    ),
+    C(
+            "ITEM_C",
+            30000,
+            "short description of Item C",
+            "landing page description of Item C",
+            List.of("http://item-c-image-1", "http://item-c-image-2", "http://item-c-image-3", "http://item-c-image-4")
+    );
+
+    private final String name;
+    private final Integer price;
+    private final String shortDescription;
+    private final String landingPageDescription;
+    private final List<String> imageUrls;
+
+    ItemFixture(
+            String name,
+            Integer price,
+            String shortDescription,
+            String landingPageDescription,
+            List<String> imageUrls
+    ) {
+        this.name = name;
+        this.price = price;
+        this.shortDescription = shortDescription;
+        this.landingPageDescription = landingPageDescription;
+        this.imageUrls = imageUrls;
+    }
+
+    public Item getInstance() {
+        Item item = Item.builder()
+                .name(name)
+                .price(price)
+                .shortDescription(shortDescription)
+                .landingPageDescription(landingPageDescription)
+                .build();
+
+        List<ItemImage> itemImages = imageUrls.stream()
+                .map(this::createItemImageFromUrl)
+                .toList();
+
+        item.addItemImages(itemImages);
+
+        return item;
+    }
+
+    private ItemImage createItemImageFromUrl(String url) {
+        return ItemImage.builder()
+                .imageUrl(url)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
클라이언트 조회 API를 구현했습니다.
1. 랜딩 페이지를 위한 클라이언트 조회 API
2. 모바일 홈 화면을 위한 클라이언트 목록 조회 API

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#26 

## 📝 참고할 사항
도메인의 오탈자를 수정했습니다.
`Client` 엔티티에 `ClientType` 속성을 추가했습니다.