### PR TITLE
[fix/#15] 회원가입/로그인 API의 버그 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ Thumbs.db
 
 # Credientials
 credentials.json
+
+# environment
+.env

--- a/src/main/java/goodspace/backend/authorization/controller/GoodSpaceAuthorizationController.java
+++ b/src/main/java/goodspace/backend/authorization/controller/GoodSpaceAuthorizationController.java
@@ -10,6 +10,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,7 +29,7 @@ public class GoodSpaceAuthorizationController {
             summary = "회원가입",
             description = "전달받은 정보를 통해 새로운 회원을 생성합니다"
     )
-    public ResponseEntity<TokenResponseDto> signUp(SignUpRequestDto requestDto) {
+    public ResponseEntity<TokenResponseDto> signUp(@RequestBody SignUpRequestDto requestDto) {
         TokenResponseDto responseDto = goodSpaceAuthorizationService.signUp(requestDto);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
@@ -39,7 +40,7 @@ public class GoodSpaceAuthorizationController {
             summary = "로그인",
             description = "이메일과 비밀번호를 통해 사용자를 인증하고 JWT 토큰을 발급합니다"
     )
-    public ResponseEntity<TokenResponseDto> signIn(SignInRequestDto requestDto) {
+    public ResponseEntity<TokenResponseDto> signIn(@RequestBody SignInRequestDto requestDto) {
         TokenResponseDto responseDto = goodSpaceAuthorizationService.signIn(requestDto);
 
         return ResponseEntity.ok(responseDto);

--- a/src/main/java/goodspace/backend/email/entity/EmailVerification.java
+++ b/src/main/java/goodspace/backend/email/entity/EmailVerification.java
@@ -1,10 +1,8 @@
 package goodspace.backend.email.entity;
 
 import goodspace.backend.domain.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,11 +21,13 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 public class EmailVerification extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     /**
      * 인증 대상 이메일 (PK)
      */
-    @Id
     @Column(nullable = false, length = 254)
     private String email;
 

--- a/src/main/java/goodspace/backend/email/repository/EmailVerificationRepository.java
+++ b/src/main/java/goodspace/backend/email/repository/EmailVerificationRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface EmailVerificationRepository extends JpaRepository<EmailVerification, String> {
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
     Optional<EmailVerification> findByEmail(String email);
 }

--- a/src/main/java/goodspace/backend/email/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/goodspace/backend/email/service/EmailVerificationServiceImpl.java
@@ -65,7 +65,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
         String email = requestDto.email();
         String code = requestDto.code();
 
-        EmailVerification emailVerification = emailVerificationRepository.findById(email)
+        EmailVerification emailVerification = emailVerificationRepository.findByEmail(email)
                 .orElseThrow(EMAIL_NOT_FOUND);
 
         if (emailVerification.isExpired(LocalDateTime.now())) {


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
1. 액션 메서드의 파라미터에 `RequestBody` 어노태이션이 누락된 문제를 수정했습니다.
2. `EmailVerification` 엔티티가 별도의 기본키를 가지도록 수정했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#15 

## 📝 참고할 사항

## 🎯 코드 리뷰 시 중점적으로 보면 좋은 내용
