### PR TITLE
[chore/#7] Client와 Item에 공개/비공개 속성 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ credentials.json
 
 # environment
 .env
+
+# client image
+images/**

--- a/src/main/java/goodspace/backend/admin/dto/client/ClientInfoResponseDto.java
+++ b/src/main/java/goodspace/backend/admin/dto/client/ClientInfoResponseDto.java
@@ -2,6 +2,7 @@ package goodspace.backend.admin.dto.client;
 
 import goodspace.backend.client.domain.Client;
 import goodspace.backend.client.domain.ClientType;
+import goodspace.backend.client.domain.RegisterStatus;
 import lombok.Builder;
 
 @Builder
@@ -11,7 +12,8 @@ public record ClientInfoResponseDto(
         String profileImageUrl,
         String backgroundImageUrl,
         String introduction,
-        ClientType clientType
+        ClientType clientType,
+        RegisterStatus status
 ) {
     public static ClientInfoResponseDto from(Client client) {
         return ClientInfoResponseDto.builder()
@@ -21,6 +23,7 @@ public record ClientInfoResponseDto(
                 .backgroundImageUrl(client.getBackgroundImageUrl())
                 .introduction(client.getIntroduction())
                 .clientType(client.getClientType())
+                .status(client.getStatus())
                 .build();
     }
 }

--- a/src/main/java/goodspace/backend/admin/dto/client/ClientUpdateRequestDto.java
+++ b/src/main/java/goodspace/backend/admin/dto/client/ClientUpdateRequestDto.java
@@ -1,6 +1,7 @@
 package goodspace.backend.admin.dto.client;
 
 import goodspace.backend.client.domain.ClientType;
+import goodspace.backend.client.domain.RegisterStatus;
 import lombok.Builder;
 
 @Builder
@@ -12,6 +13,7 @@ public record ClientUpdateRequestDto(
         String encodedBackgroundImage,
         boolean backgroundUpdated,
         String introduction,
-        ClientType clientType
+        ClientType clientType,
+        RegisterStatus status
 ) {
 }

--- a/src/main/java/goodspace/backend/admin/dto/item/ItemInfoResponseDto.java
+++ b/src/main/java/goodspace/backend/admin/dto/item/ItemInfoResponseDto.java
@@ -1,5 +1,6 @@
 package goodspace.backend.admin.dto.item;
 
+import goodspace.backend.client.domain.RegisterStatus;
 import goodspace.backend.global.domain.Item;
 import lombok.Builder;
 
@@ -12,6 +13,7 @@ public record ItemInfoResponseDto(
         Integer price,
         String shortDescription,
         String landingPageDescription,
+        RegisterStatus status,
         List<String> imageUrls
 ) {
     public static ItemInfoResponseDto from(Item item) {
@@ -21,6 +23,7 @@ public record ItemInfoResponseDto(
                 .price(item.getPrice())
                 .shortDescription(item.getShortDescription())
                 .landingPageDescription(item.getLandingPageDescription())
+                .status(item.getStatus())
                 .imageUrls(item.getImageUrls())
                 .build();
     }

--- a/src/main/java/goodspace/backend/admin/dto/item/ItemUpdateRequestDto.java
+++ b/src/main/java/goodspace/backend/admin/dto/item/ItemUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package goodspace.backend.admin.dto.item;
 
+import goodspace.backend.client.domain.RegisterStatus;
 import lombok.Builder;
 
 @Builder
@@ -9,6 +10,7 @@ public record ItemUpdateRequestDto(
         String name,
         Integer price,
         String shortDescription,
-        String landingPageDescription
+        String landingPageDescription,
+        RegisterStatus status
 ) {
 }

--- a/src/main/java/goodspace/backend/admin/service/client/ClientManageServiceImpl.java
+++ b/src/main/java/goodspace/backend/admin/service/client/ClientManageServiceImpl.java
@@ -5,6 +5,7 @@ import goodspace.backend.admin.dto.client.ClientRegisterRequestDto;
 import goodspace.backend.admin.dto.client.ClientUpdateRequestDto;
 import goodspace.backend.admin.image.ImageManager;
 import goodspace.backend.client.domain.Client;
+import goodspace.backend.client.domain.RegisterStatus;
 import goodspace.backend.global.domain.Item;
 import goodspace.backend.client.repository.ClientRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -52,6 +53,7 @@ public class ClientManageServiceImpl implements ClientManageService {
                 .name(clientDto.name())
                 .introduction(clientDto.introduction())
                 .clientType(clientDto.clientType())
+                .status(RegisterStatus.PRIVATE)
                 .build());
 
         client.setProfileImageUrl(imageManager.createImageUrl(client.getId().toString(), PROFILE, clientDto.encodedProfileImage()));
@@ -76,7 +78,8 @@ public class ClientManageServiceImpl implements ClientManageService {
         client.update(
                 requestDto.name(),
                 requestDto.introduction(),
-                requestDto.clientType()
+                requestDto.clientType(),
+                requestDto.status()
         );
 
         return ClientInfoResponseDto.from(client);

--- a/src/main/java/goodspace/backend/admin/service/item/ItemManageService.java
+++ b/src/main/java/goodspace/backend/admin/service/item/ItemManageService.java
@@ -1,9 +1,6 @@
 package goodspace.backend.admin.service.item;
 
-import goodspace.backend.admin.dto.item.ItemDeleteRequestDto;
-import goodspace.backend.admin.dto.item.ItemInfoResponseDto;
-import goodspace.backend.admin.dto.item.ItemRegisterRequestDto;
-import goodspace.backend.admin.dto.item.ItemUpdateRequestDto;
+import goodspace.backend.admin.dto.item.*;
 
 import java.util.List;
 

--- a/src/main/java/goodspace/backend/admin/service/item/ItemManageServiceImpl.java
+++ b/src/main/java/goodspace/backend/admin/service/item/ItemManageServiceImpl.java
@@ -6,6 +6,7 @@ import goodspace.backend.admin.dto.item.ItemRegisterRequestDto;
 import goodspace.backend.admin.dto.item.ItemUpdateRequestDto;
 import goodspace.backend.admin.image.ImageManager;
 import goodspace.backend.client.domain.Client;
+import goodspace.backend.client.domain.RegisterStatus;
 import goodspace.backend.global.domain.Item;
 import goodspace.backend.client.repository.ClientRepository;
 import goodspace.backend.global.repository.ItemRepository;
@@ -45,7 +46,7 @@ public class ItemManageServiceImpl implements ItemManageService {
         Client client = clientRepository.findById(requestDto.clientId())
                 .orElseThrow(CLIENT_NOT_FOUND);
 
-        Item item = createItem(requestDto);
+        Item item = createItem(requestDto, RegisterStatus.PRIVATE);
         client.addItem(item);
 
         return ItemInfoResponseDto.from(itemRepository.save(item));
@@ -62,7 +63,8 @@ public class ItemManageServiceImpl implements ItemManageService {
                 requestDto.name(),
                 requestDto.price(),
                 requestDto.shortDescription(),
-                requestDto.landingPageDescription()
+                requestDto.landingPageDescription(),
+                requestDto.status()
         );
 
         return ItemInfoResponseDto.from(item);
@@ -83,12 +85,13 @@ public class ItemManageServiceImpl implements ItemManageService {
         client.removeItem(item);
     }
 
-    private Item createItem(ItemRegisterRequestDto itemDto) {
+    private Item createItem(ItemRegisterRequestDto itemDto, RegisterStatus status) {
         return Item.builder()
                 .name(itemDto.name())
                 .price(itemDto.price())
                 .shortDescription(itemDto.shortDescription())
                 .landingPageDescription(itemDto.landingPageDescription())
+                .status(status)
                 .build();
     }
 

--- a/src/main/java/goodspace/backend/client/controller/ClientController.java
+++ b/src/main/java/goodspace/backend/client/controller/ClientController.java
@@ -30,7 +30,7 @@ public class ClientController {
             description = "모든 클라이언트에 대한 간략한 정보를 반환합니다"
     )
     public ResponseEntity<List<ClientBriefInfoResponseDto>> findClients() {
-        List<ClientBriefInfoResponseDto> responseDto = clientService.getClients();
+        List<ClientBriefInfoResponseDto> responseDto = clientService.getPublicClients();
 
         return ResponseEntity.ok(responseDto);
     }

--- a/src/main/java/goodspace/backend/client/domain/Client.java
+++ b/src/main/java/goodspace/backend/client/domain/Client.java
@@ -28,7 +28,11 @@ public class Client extends BaseEntity {
     @Column(nullable = false)
     private String introduction;
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
     private ClientType clientType;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private RegisterStatus status;
 
     @OneToMany(mappedBy = "client", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
@@ -37,11 +41,23 @@ public class Client extends BaseEntity {
     public void update(
             String name,
             String introduction,
-            ClientType clientType
+            ClientType clientType,
+            RegisterStatus status
     ) {
         this.name = name;
         this.introduction = introduction;
         this.clientType = clientType;
+        this.status = status;
+    }
+
+    public boolean isPublic() {
+        return status == RegisterStatus.PUBLIC;
+    }
+
+    public List<Item> getPublicItems() {
+        return items.stream()
+                .filter(Item::isPublic)
+                .toList();
     }
 
     /**

--- a/src/main/java/goodspace/backend/client/domain/RegisterStatus.java
+++ b/src/main/java/goodspace/backend/client/domain/RegisterStatus.java
@@ -1,0 +1,5 @@
+package goodspace.backend.client.domain;
+
+public enum RegisterStatus {
+    PRIVATE, PUBLIC
+}

--- a/src/main/java/goodspace/backend/client/dto/ClientDetailsResponseDto.java
+++ b/src/main/java/goodspace/backend/client/dto/ClientDetailsResponseDto.java
@@ -1,6 +1,7 @@
 package goodspace.backend.client.dto;
 
 import goodspace.backend.client.domain.Client;
+import goodspace.backend.global.domain.Item;
 import lombok.Builder;
 
 import java.util.List;
@@ -13,8 +14,8 @@ public record ClientDetailsResponseDto(
         String introduction,
         List<ItemBriefInfoResponseDto> items
 ) {
-    public static ClientDetailsResponseDto from(Client client) {
-        List<ItemBriefInfoResponseDto> items = client.getItems().stream()
+    public static ClientDetailsResponseDto of(Client client, boolean completeStatusOnly) {
+        List<ItemBriefInfoResponseDto> items = getQualifiedItems(client, completeStatusOnly).stream()
                 .map(ItemBriefInfoResponseDto::from)
                 .toList();
 
@@ -25,5 +26,13 @@ public record ClientDetailsResponseDto(
                 .introduction(client.getIntroduction())
                 .items(items)
                 .build();
+    }
+
+    private static List<Item> getQualifiedItems(Client client, boolean completeStatusOnly) {
+        if (completeStatusOnly) {
+            return client.getPublicItems();
+        }
+
+        return client.getItems();
     }
 }

--- a/src/main/java/goodspace/backend/client/service/ClientService.java
+++ b/src/main/java/goodspace/backend/client/service/ClientService.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface ClientService {
     ClientDetailsResponseDto getDetails(long clientId);
 
-    List<ClientBriefInfoResponseDto> getClients();
+    List<ClientBriefInfoResponseDto> getPublicClients();
 }

--- a/src/main/java/goodspace/backend/global/domain/Item.java
+++ b/src/main/java/goodspace/backend/global/domain/Item.java
@@ -1,6 +1,7 @@
 package goodspace.backend.global.domain;
 
 import goodspace.backend.client.domain.Client;
+import goodspace.backend.client.domain.RegisterStatus;
 import goodspace.backend.order.domain.Order;
 import jakarta.persistence.*;
 import lombok.*;
@@ -23,6 +24,10 @@ public class Item extends BaseEntity {
     private String shortDescription;
     private String landingPageDescription;
 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private RegisterStatus status;
+
     @ManyToOne
     @JoinColumn(name = "client_id")
     @Setter
@@ -43,16 +48,22 @@ public class Item extends BaseEntity {
                 .toList();
     }
 
+    public boolean isPublic() {
+        return status == RegisterStatus.PUBLIC;
+    }
+
     public void update(
             String name,
             Integer price,
             String shortDescription,
-            String landingPageDescription
+            String landingPageDescription,
+            RegisterStatus status
     ) {
         this.name = name;
         this.price = price;
         this.shortDescription = shortDescription;
         this.landingPageDescription = landingPageDescription;
+        this.status = status;
     }
 
     /**

--- a/src/test/java/goodspace/backend/admin/service/client/ClientManageServiceTest.java
+++ b/src/test/java/goodspace/backend/admin/service/client/ClientManageServiceTest.java
@@ -235,7 +235,8 @@ class ClientManageServiceTest {
                 client.getProfileImageUrl().equals(dto.profileImageUrl()) &&
                 client.getBackgroundImageUrl().equals(dto.backgroundImageUrl()) &&
                 client.getIntroduction().equals(dto.introduction()) &&
-                client.getClientType() == dto.clientType();
+                client.getClientType() == dto.clientType() &&
+                client.getStatus() == dto.status();
     }
 
     private boolean isEqualWithoutImage(ClientInfoResponseDto clientDto, ClientRegisterRequestDto requestDto) {
@@ -248,6 +249,7 @@ class ClientManageServiceTest {
         return client.getId().equals(dto.id()) &&
                 client.getName().equals(dto.name()) &&
                 client.getIntroduction().equals(dto.introduction()) &&
-                client.getClientType() == dto.clientType();
+                client.getClientType() == dto.clientType() &&
+                client.getStatus() == dto.status();
     }
 }

--- a/src/test/java/goodspace/backend/admin/service/item/ItemManageServiceTest.java
+++ b/src/test/java/goodspace/backend/admin/service/item/ItemManageServiceTest.java
@@ -71,8 +71,8 @@ class ItemManageServiceTest {
         imageManager = new ImageManagerImpl(basePath.toString());
 
         client = clientRepository.save(ClientFixture.CREATOR.getInstance());
-        itemA = itemRepository.save(ItemFixture.A.getInstance());
-        itemB = itemRepository.save(ItemFixture.B.getInstance());
+        itemA = itemRepository.save(ItemFixture.PUBLIC_A.getInstance());
+        itemB = itemRepository.save(ItemFixture.PUBLIC_B.getInstance());
 
         itemImageA = itemImageRepository.save(ItemImage.getEmptyInstance());
         itemImageB = itemImageRepository.save(ItemImage.getEmptyInstance());
@@ -181,6 +181,7 @@ class ItemManageServiceTest {
                 item.getPrice().equals(dto.price()) &&
                 item.getShortDescription().equals(dto.shortDescription()) &&
                 item.getLandingPageDescription().equals(dto.landingPageDescription()) &&
+                item.getStatus() == dto.status() &&
                 itemUrlSet.equals(dtoUrlSet);
     }
 
@@ -197,7 +198,8 @@ class ItemManageServiceTest {
                 item.getName().equals(dto.name()) &&
                 item.getPrice().equals(dto.price()) &&
                 item.getShortDescription().equals(dto.shortDescription()) &&
-                item.getLandingPageDescription().equals(dto.landingPageDescription());
+                item.getLandingPageDescription().equals(dto.landingPageDescription()) &&
+                item.getStatus() == dto.status();
     }
 
     private boolean isClientHasItem(Client client, long itemId) {

--- a/src/test/java/goodspace/backend/admin/service/itemImage/ItemImageManageServiceTest.java
+++ b/src/test/java/goodspace/backend/admin/service/itemImage/ItemImageManageServiceTest.java
@@ -67,7 +67,7 @@ class ItemImageManageServiceTest {
         itemImageManageService = new ItemImageManageServiceImpl(imageManager, itemRepository, itemImageRepository);
 
         client = clientRepository.save(ClientFixture.CREATOR.getInstance());
-        item = itemRepository.save(ItemFixture.D.getInstance());
+        item = itemRepository.save(ItemFixture.PUBLIC_A.getInstance());
         itemImageA = itemImageRepository.save(ItemImage.getEmptyInstance());
         itemImageB = itemImageRepository.save(ItemImage.getEmptyInstance());
 

--- a/src/test/java/goodspace/backend/fixture/ClientFixture.java
+++ b/src/test/java/goodspace/backend/fixture/ClientFixture.java
@@ -2,6 +2,7 @@ package goodspace.backend.fixture;
 
 import goodspace.backend.client.domain.Client;
 import goodspace.backend.client.domain.ClientType;
+import goodspace.backend.client.domain.RegisterStatus;
 
 public enum ClientFixture {
     INFLUENCER(
@@ -9,21 +10,40 @@ public enum ClientFixture {
             "http://influencer-kim-profile",
             "http://influencer-kim-bg",
             "Hello, I'm Influencer Kim!",
-            ClientType.INFLUENCER
+            ClientType.INFLUENCER,
+            RegisterStatus.PUBLIC
     ),
     CREATOR(
             "CREATOR PARK",
             "http://creator-park-profile",
             "http://creator-park-bg",
             "Hello, I'm Creator Park!",
-            ClientType.CREATOR
+            ClientType.CREATOR,
+            RegisterStatus.PUBLIC
     ),
     YOUTUBER(
             "YOUTUBER LEE",
             "http://youtuber-lee-profile",
             "http://youtuber-lee-bg",
             "Hello, I'm Youtuber Lee!",
-            ClientType.CREATOR
+            ClientType.CREATOR,
+            RegisterStatus.PUBLIC
+    ),
+    SINGER(
+            "SIGNER JSON",
+            "json/profile",
+            "json/bg",
+            "Hello, I'm Singer Json!",
+            ClientType.CREATOR,
+            RegisterStatus.PUBLIC
+    ),
+    PRIVATE_CLIENT(
+            "PRIVATE CLIENT",
+            "private/profile",
+            "private/bg",
+            "Hello, I'm Private Client!",
+            ClientType.CREATOR,
+            RegisterStatus.PRIVATE
     );
 
     private final String name;
@@ -31,19 +51,22 @@ public enum ClientFixture {
     private final String backgroundImageUrl;
     private final String introduction;
     private final ClientType clientType;
+    private final RegisterStatus status;
 
     ClientFixture(
             String name,
             String profileImageUrl,
             String backgroundImageUrl,
             String introduction,
-            ClientType clientType
+            ClientType clientType,
+            RegisterStatus status
     ) {
         this.name = name;
         this.profileImageUrl = profileImageUrl;
         this.backgroundImageUrl = backgroundImageUrl;
         this.introduction = introduction;
         this.clientType = clientType;
+        this.status = status;
     }
 
     public Client getInstance() {
@@ -53,6 +76,7 @@ public enum ClientFixture {
                 .backgroundImageUrl(backgroundImageUrl)
                 .introduction(introduction)
                 .clientType(clientType)
+                .status(status)
                 .build();
     }
 }

--- a/src/test/java/goodspace/backend/fixture/ItemFixture.java
+++ b/src/test/java/goodspace/backend/fixture/ItemFixture.java
@@ -1,48 +1,70 @@
 package goodspace.backend.fixture;
 
+import goodspace.backend.client.domain.RegisterStatus;
 import goodspace.backend.global.domain.Item;
 
 public enum ItemFixture {
-    A(
-            "ITEM_A",
+    PUBLIC_A(
+            "PUBLIC_A",
             15000,
-            "short description of Item A",
-            "landing page description of Item A"
+            "short description of Item CA",
+            "landing page description of Item CA",
+            RegisterStatus.PUBLIC
     ),
-    B(
-            "ITEM_B",
+    PUBLIC_B(
+            "PUBLIC_B",
             20000,
-            "short description of Item B",
-            "landing page description of Item B"
+            "short description of Item CB",
+            "landing page description of Item CB",
+            RegisterStatus.PUBLIC
     ),
-    C(
-            "ITEM_C",
+    PUBLIC_C(
+            "PUBLIC_C",
             30000,
-            "short description of Item C",
-            "landing page description of Item C"
+            "short description of Item CC",
+            "landing page description of Item CC",
+            RegisterStatus.PUBLIC
     ),
-    D(
-            "ITEM_D",
+    PRIVATE_A(
+            "PRIVATE_A",
             40000,
-            "short description of Item D",
-            "landing page description of Item D"
+            "short description of Item TA",
+            "landing page description of Item TA",
+            RegisterStatus.PRIVATE
+    ),
+    PRIVATE_B(
+            "PRIVATE_B",
+            40000,
+            "short description of Item TB",
+            "landing page description of Item TB",
+            RegisterStatus.PRIVATE
+    ),
+    PRIVATE_C(
+            "PRIVATE_C",
+            40000,
+            "short description of Item TC",
+            "landing page description of Item TC",
+            RegisterStatus.PRIVATE
     );
 
     private final String name;
     private final Integer price;
     private final String shortDescription;
     private final String landingPageDescription;
+    private final RegisterStatus status;
 
     ItemFixture(
             String name,
             Integer price,
             String shortDescription,
-            String landingPageDescription
+            String landingPageDescription,
+            RegisterStatus status
     ) {
         this.name = name;
         this.price = price;
         this.shortDescription = shortDescription;
         this.landingPageDescription = landingPageDescription;
+        this.status = status;
     }
 
     public Item getInstance() {
@@ -51,6 +73,7 @@ public enum ItemFixture {
                 .price(price)
                 .shortDescription(shortDescription)
                 .landingPageDescription(landingPageDescription)
+                .status(status)
                 .build();
     }
 }


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
- `Client`와 `Item` 엔티티에 공개/비공개 상태를 나타내는 `status` 속성을 추가했습니다.
- 클라이언트 혹은 상품 데이터를 임시로 등록할 수 있게 하기 위함입니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#7 

