### PR TITLE
[feature/#42] 전역 예외 핸들러 구현

### DIFF
--- a/src/main/java/goodspace/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/goodspace/backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,97 @@
+package goodspace.backend.global.exception;
+
+import io.jsonwebtoken.MalformedJwtException;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.sql.SQLException;
+
+import static org.springframework.http.HttpStatus.*;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<String> handleNotFound(NoHandlerFoundException exception) {
+        log.trace("[ERROR RESPONSE] handleNotFound", exception);
+
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body("존재하지 않는 엔드포인트입니다");
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleBeanValidation(MethodArgumentNotValidException exception) {
+        log.info("[ERROR RESPONSE] bean validation", exception);
+
+        FieldError fieldError = exception.getBindingResult()
+                .getFieldErrors()
+                .get(0);
+
+        return ResponseEntity.status(BAD_REQUEST).body(fieldError.getDefaultMessage());
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<String> handleEntityNotFound(EntityNotFoundException exception) {
+        log.trace("[ERROR RESPONSE] entity not found", exception);
+
+        return ResponseEntity.status(UNPROCESSABLE_ENTITY).body(exception.getMessage());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException exception) {
+        log.trace("[ERROR RESPONSE] illegal argument", exception);
+
+        return ResponseEntity.status(BAD_REQUEST).body("Illegal argument: " + exception.getMessage());
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<String> handleIllegalState(IllegalStateException exception) {
+        log.trace("[ERROR RESPONSE] illegal state", exception);
+
+        return ResponseEntity.status(BAD_REQUEST).body("Illegal state: " + exception.getMessage());
+    }
+
+    @ExceptionHandler(MalformedJwtException.class)
+    public ResponseEntity<String> handleIllegalJwt(MalformedJwtException exception) {
+        log.trace("[ERROR RESPONSE] malformed jwt", exception);
+
+        return ResponseEntity.status(UNAUTHORIZED).body("부적절한 JWT 토큰입니다: " + exception.getMessage());
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<String> handleIllegalJson(HttpMessageNotReadableException exception) {
+        log.trace("[ERROR RESPONSE] http message not readable", exception);
+
+        return ResponseEntity.status(BAD_REQUEST).body("JSON 파싱에 실패했습니다: " + exception.getMessage());
+    }
+
+    @ExceptionHandler(SQLException.class)
+    public ResponseEntity<String> handleSQLException(SQLException exception) {
+        log.warn("[ERROR RESPONSE] sql exception", exception);
+
+        return ResponseEntity.status(CONFLICT).body("SQL exception: " + exception.getMessage());
+    }
+
+    @ExceptionHandler({DataIntegrityViolationException.class, ConstraintViolationException.class})
+    public ResponseEntity<String>  handleDataIntegrityViolation(DataIntegrityViolationException exception) {
+        log.warn("[ERROR RESPONSE] data integrity violation", exception);
+
+        return ResponseEntity.status(CONFLICT).body("DB 무결성 제약조건에 위반됩니다: " + exception.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handle(Exception exception) {
+        log.error("[ERROR RESPONSE] unexpected exception", exception);
+
+        return ResponseEntity.status(INTERNAL_SERVER_ERROR).body("예상하지 못한 예외가 발생했습니다: " + exception.getMessage());
+    }
+}


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
- 모든 `RestController`가 사용할 수 있는 예외 핸들러를 추가했습니다.
- 클라이언트와 소통하는 과정에서 디버깅에 용이하기 위해 추가했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#42 

## 📝 참고할 사항
클라이언트 측 문제로 발생했을 확률이 높은 예외는 `trace` 수준으로 로깅했습니다.
해당 예외의 스택 트레이스를 확인하기 위해서는, `application.yml`에 `logging.level.root=trace` 설정이 필요합니다.
