### PR TITLE
[fix/#54] 일반 이미지 목록에 타이틀 이미지가 포함되던 문제 해결

### DIFF
--- a/src/main/java/goodspace/backend/global/domain/Item.java
+++ b/src/main/java/goodspace/backend/global/domain/Item.java
@@ -45,8 +45,15 @@ public class Item extends BaseEntity {
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     private ItemImage titleImage;
 
+    public List<ItemImage> getItemImages() {
+        return itemImages.stream()
+                .filter(itemImage -> itemImage != titleImage)
+                .toList();
+    }
+
     public List<String> getImageUrls() {
         return itemImages.stream()
+                .filter(itemImage -> itemImage != titleImage)
                 .map(ItemImage::getImageUrl)
                 .toList();
     }
@@ -87,14 +94,18 @@ public class Item extends BaseEntity {
         }
     }
 
-    public void setTitleImage(ItemImage itemImage) {
-        this.titleImage = itemImage;
+    public void addItemImage(ItemImage itemImage) {
+        itemImages.add(itemImage);
         itemImage.setItem(this);
     }
 
+    public void setTitleImage(ItemImage itemImage) {
+        this.titleImage = itemImage;
+        addItemImage(titleImage);
+    }
+
     public void removeTitleImage() {
-        titleImage.setItem(null);
-        titleImage = null;
+        removeItemImage(titleImage);
     }
 
     public void removeItemImage(ItemImage itemImage) {


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
`Item` 엔티티의 `items` 속성에도 `titleImage`가 중복되어 포함되는 문제를 발견했습니다.
Getter/Setter에 필터 로직을 추가해, 클라이언트 코드 입장에서 `items`와 `titleImage`를 별도의 속성으로 다룰 수 있게 만들었습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#54 
