### PR TITLE
[feat/#57] 상품 단건 조회 API 구현

### DIFF
--- a/src/main/java/goodspace/backend/client/controller/ClientController.java
+++ b/src/main/java/goodspace/backend/client/controller/ClientController.java
@@ -2,6 +2,7 @@ package goodspace.backend.client.controller;
 
 import goodspace.backend.client.dto.ClientBriefInfoResponseDto;
 import goodspace.backend.client.dto.ClientDetailsResponseDto;
+import goodspace.backend.client.dto.ClientItemInfoResponseDto;
 import goodspace.backend.client.service.ClientService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -42,6 +43,20 @@ public class ClientController {
     )
     public ResponseEntity<ClientDetailsResponseDto> findClientDetails(@PathVariable long clientId) {
         ClientDetailsResponseDto responseDto = clientService.getDetails(clientId);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @GetMapping("/{clientId}/{itemId}")
+    @Operation(
+            summary = "상품 조회",
+            description = "클라이언트의 정보와 단일 상품의 정보를 반환합니다(상품 상세 페이지 용도)"
+    )
+    public ResponseEntity<ClientItemInfoResponseDto> findClientAndItem(
+            @PathVariable long clientId,
+            @PathVariable long itemId
+    ) {
+        ClientItemInfoResponseDto responseDto =clientService.getClientAndItem(clientId, itemId);
 
         return ResponseEntity.ok(responseDto);
     }

--- a/src/main/java/goodspace/backend/client/dto/ClientItemInfoResponseDto.java
+++ b/src/main/java/goodspace/backend/client/dto/ClientItemInfoResponseDto.java
@@ -1,0 +1,55 @@
+package goodspace.backend.client.dto;
+
+import goodspace.backend.client.domain.Client;
+import goodspace.backend.global.domain.Item;
+import lombok.Builder;
+
+import java.util.List;
+
+// TODO: 배송 관련 정보를 추가해야 함
+@Builder
+public record ClientItemInfoResponseDto(
+        ClientDto client,
+        ItemDto item
+) {
+    @Builder
+    public record ClientDto(
+            long id,
+            String name,
+            String profileImageUrl
+    ) {
+    }
+
+    @Builder
+    public record ItemDto(
+            long id,
+            String name,
+            Integer price,
+            String shortDescription,
+            String landingPageDescription,
+            List<String> imageUrls
+    ) {
+    }
+
+    public static ClientItemInfoResponseDto of(Client client, Item item) {
+        ClientDto clientDto = ClientDto.builder()
+                .id(client.getId())
+                .name(client.getName())
+                .profileImageUrl(client.getProfileImageUrl())
+                .build();
+
+        ItemDto itemDto = ItemDto.builder()
+                .id(item.getId())
+                .name(item.getName())
+                .price(item.getPrice())
+                .shortDescription(item.getShortDescription())
+                .landingPageDescription(item.getLandingPageDescription())
+                .imageUrls(item.getEveryImageUrl())
+                .build();
+
+        return ClientItemInfoResponseDto.builder()
+                .client(clientDto)
+                .item(itemDto)
+                .build();
+    }
+}

--- a/src/main/java/goodspace/backend/client/service/ClientService.java
+++ b/src/main/java/goodspace/backend/client/service/ClientService.java
@@ -2,6 +2,7 @@ package goodspace.backend.client.service;
 
 import goodspace.backend.client.dto.ClientBriefInfoResponseDto;
 import goodspace.backend.client.dto.ClientDetailsResponseDto;
+import goodspace.backend.client.dto.ClientItemInfoResponseDto;
 
 import java.util.List;
 
@@ -9,4 +10,6 @@ public interface ClientService {
     ClientDetailsResponseDto getDetails(long clientId);
 
     List<ClientBriefInfoResponseDto> getPublicClients();
+
+    ClientItemInfoResponseDto getClientAndItem(long clientId, long itemId);
 }

--- a/src/main/java/goodspace/backend/client/service/ClientServiceImpl.java
+++ b/src/main/java/goodspace/backend/client/service/ClientServiceImpl.java
@@ -3,7 +3,9 @@ package goodspace.backend.client.service;
 import goodspace.backend.client.dto.ClientBriefInfoResponseDto;
 import goodspace.backend.client.dto.ClientDetailsResponseDto;
 import goodspace.backend.client.domain.Client;
+import goodspace.backend.client.dto.ClientItemInfoResponseDto;
 import goodspace.backend.client.repository.ClientRepository;
+import goodspace.backend.global.domain.Item;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,8 @@ import java.util.function.Supplier;
 public class ClientServiceImpl implements ClientService {
     private static final Supplier<EntityNotFoundException> CLIENT_NOT_FOUND = () -> new EntityNotFoundException("클라이언트를 찾지 못했습니다.");
     private static final Supplier<IllegalStateException> PRIVATE_CLIENT = () -> new IllegalStateException("공개되지 않은 클라이언트입니다.");
+    private static final Supplier<EntityNotFoundException> ITEM_NOT_FOUND = () -> new EntityNotFoundException("상품을 찾지 못했습니다.");
+    private static final Supplier<IllegalStateException> PRIVATE_ITEM = () -> new IllegalStateException("공개되지 않은 상품입니다.");
 
     private final ClientRepository clientRepository;
 
@@ -24,9 +28,7 @@ public class ClientServiceImpl implements ClientService {
         Client client = clientRepository.findById(clientId)
                 .orElseThrow(CLIENT_NOT_FOUND);
 
-        if (!client.isPublic()) {
-            throw PRIVATE_CLIENT.get();
-        }
+        throwExceptionIfPrivate(client);
 
         return ClientDetailsResponseDto.of(client, true);
     }
@@ -39,5 +41,36 @@ public class ClientServiceImpl implements ClientService {
                 .filter(Client::isPublic)
                 .map(ClientBriefInfoResponseDto::from)
                 .toList();
+    }
+
+    @Override
+    public ClientItemInfoResponseDto getClientAndItem(long clientId, long itemId) {
+        Client client = clientRepository.findById(clientId)
+                .orElseThrow(CLIENT_NOT_FOUND);
+        Item item = findItemFromClient(client, itemId);
+
+        throwExceptionIfPrivate(client);
+        throwExceptionIfPrivate(item);
+
+        return ClientItemInfoResponseDto.of(client, item);
+    }
+
+    private Item findItemFromClient(Client client, long itemId) {
+        return client.getItems().stream()
+                .filter(item -> item.getId().equals(itemId))
+                .findAny()
+                .orElseThrow(ITEM_NOT_FOUND);
+    }
+
+    private void throwExceptionIfPrivate(Client client) {
+        if (!client.isPublic()) {
+            throw PRIVATE_CLIENT.get();
+        }
+    }
+
+    private void throwExceptionIfPrivate(Item item) {
+        if (!item.isPublic()) {
+            throw PRIVATE_ITEM.get();
+        }
     }
 }

--- a/src/main/java/goodspace/backend/global/domain/Item.java
+++ b/src/main/java/goodspace/backend/global/domain/Item.java
@@ -51,6 +51,12 @@ public class Item extends BaseEntity {
                 .toList();
     }
 
+    public List<String> getEveryImageUrl() {
+        return itemImages.stream()
+                .map(ItemImage::getImageUrl)
+                .toList();
+    }
+
     public List<String> getImageUrls() {
         return itemImages.stream()
                 .filter(itemImage -> itemImage != titleImage)


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
상품 상세 조회 페이지를 위한 API를 구현했습니다.
테스트 코드를 추가하고, 기존의 테스트 코드를 간결하게 개선했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#57 

## 📝 참고할 사항
후에, 상품 상세 페이지에 띄워줄 배송 정보 안내 API 구현이 필요합니다.
