### PR TITLE
[build] Spring Framework 버전과 호환되는 SpringDoc 버전으로 교체

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
 
     // SpringDoc OpenAPI (Swagger UI)
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
     // Gson
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
SpringDoc의 버전을 최신 버전으로 수정했습니다.

기존 Spring Framework와의 호환성 문제로 인해, `ControllerAdviceBean`의 생성자를 찾지 못하던 문제가 있었습니다.
이로 인해 Swagger가 정상 동작하지 않았던 것을 해결했습니다.
