### PR TITLE
[chore/#67] 관리자 계정 초기화 시에도 비밀번호 해싱 적용

### DIFF
--- a/src/main/java/goodspace/backend/admin/service/AdminInitializeService.java
+++ b/src/main/java/goodspace/backend/admin/service/AdminInitializeService.java
@@ -6,22 +6,26 @@ import goodspace.backend.global.security.Role;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class AdminInitializeService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     private final String email;
     private final String password;
 
     public AdminInitializeService(
             UserRepository userRepository,
+            PasswordEncoder passwordEncoder,
             @Value("${admin.email:default@adminEmail.com}") String email,
             @Value("${admin.password:defaultAdminPassword}") String password
     ) {
         this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
         this.email = email;
         this.password = password;
     }
@@ -31,7 +35,7 @@ public class AdminInitializeService {
     public void initialize() {
         GoodSpaceUser user = GoodSpaceUser.builder()
                 .email(email)
-                .password(password)
+                .password(passwordEncoder.encode(password))
                 .build();
         user.addRole(Role.USER);
         user.addRole(Role.ADMIN);


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
비밀번호 해싱이 관리자 계정에 적용되지 않은 문제를 수정했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#67 
