### PR TITLE
[chore/#76] 이메일 수정 API 구현

### DIFF
--- a/src/main/java/goodspace/backend/user/controller/UserController.java
+++ b/src/main/java/goodspace/backend/user/controller/UserController.java
@@ -1,13 +1,18 @@
 package goodspace.backend.user.controller;
 
+import goodspace.backend.user.dto.EmailUpdateRequestDto;
 import goodspace.backend.user.dto.PasswordUpdateRequestDto;
 import goodspace.backend.user.dto.RefreshTokenResponseDto;
 import goodspace.backend.user.dto.UserMyPageDto;
 import goodspace.backend.user.service.UserService;
-import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.security.Principal;
 
@@ -16,21 +21,44 @@ import static java.lang.Long.parseLong;
 @RestController
 @RequestMapping("/user")
 @RequiredArgsConstructor
+@Tag(
+        name = "회원 API",
+        description = "회원 정보 관련 기능"
+)
 public class UserController {
     private final UserService userService;
 
     @PatchMapping("/updateMyPage")
+    @Operation(
+            summary = "정보 수정",
+            description = "회원 정보를 수정합니다.(마이페이지 용도)"
+    )
     public ResponseEntity<String> updateMyPage(Principal principal, @RequestBody UserMyPageDto userMyPageDto){
-        Long id = parseLong(principal.getName());
+        long id = parseLong(principal.getName());
         return ResponseEntity.ok().body(userService.updateMyPage(id, userMyPageDto));
     }
 
     @PatchMapping("/password")
+    @Operation(
+            summary = "비밀번호 수정",
+            description = "비밀번호를 수정합니다."
+    )
     public ResponseEntity<RefreshTokenResponseDto> updatePassword(Principal principal, @RequestBody PasswordUpdateRequestDto requestDto) {
-        Long id = parseLong(principal.getName());
+        long id = parseLong(principal.getName());
         RefreshTokenResponseDto responseDto = userService.updatePassword(id, requestDto);
 
         return ResponseEntity.ok(responseDto);
     }
 
+    @PatchMapping("/email")
+    @Operation(
+            summary = "이메일 수정",
+            description = "이메일을 수정합니다. (사전에 이메일 인증 필요)"
+    )
+    public ResponseEntity<RefreshTokenResponseDto> updateEmail(Principal principal, @RequestBody EmailUpdateRequestDto requestDto) {
+        long id = parseLong(principal.getName());
+        RefreshTokenResponseDto responseDto = userService.updateEmail(id, requestDto);
+
+        return ResponseEntity.ok(responseDto);
+    }
 }

--- a/src/main/java/goodspace/backend/user/domain/User.java
+++ b/src/main/java/goodspace/backend/user/domain/User.java
@@ -7,10 +7,7 @@ import goodspace.backend.global.security.RefreshToken;
 import goodspace.backend.user.dto.UserMyPageDto;
 import goodspace.backend.global.security.Role;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
@@ -31,6 +28,7 @@ public abstract class User extends BaseEntity {
     private String name;
     private Integer dateOfBirth;
     @Column(unique = true, nullable = false)
+    @Setter
     private String email;
     private String phoneNumber;
 
@@ -90,6 +88,6 @@ public abstract class User extends BaseEntity {
         this.phoneNumber = userMyPageDto.getPhoneNumber();
         this.name = userMyPageDto.getName();
         this.dateOfBirth = userMyPageDto.getDateOfBirth();
-        this.delivery = delivery.from(userMyPageDto);
+        this.delivery = Delivery.from(userMyPageDto);
     }
 }

--- a/src/main/java/goodspace/backend/user/dto/EmailUpdateRequestDto.java
+++ b/src/main/java/goodspace/backend/user/dto/EmailUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package goodspace.backend.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record EmailUpdateRequestDto(
+        String email
+) {
+}

--- a/src/main/java/goodspace/backend/user/service/UserService.java
+++ b/src/main/java/goodspace/backend/user/service/UserService.java
@@ -1,10 +1,13 @@
 package goodspace.backend.user.service;
 
+import goodspace.backend.email.entity.EmailVerification;
+import goodspace.backend.email.repository.EmailVerificationRepository;
 import goodspace.backend.global.password.PasswordValidator;
 import goodspace.backend.global.security.TokenProvider;
 import goodspace.backend.global.security.TokenType;
 import goodspace.backend.user.domain.GoodSpaceUser;
 import goodspace.backend.user.domain.User;
+import goodspace.backend.user.dto.EmailUpdateRequestDto;
 import goodspace.backend.user.dto.PasswordUpdateRequestDto;
 import goodspace.backend.user.dto.RefreshTokenResponseDto;
 import goodspace.backend.user.dto.UserMyPageDto;
@@ -23,14 +26,17 @@ public class UserService {
     private static final Supplier<EntityNotFoundException> USER_NOT_FOUND = () -> new EntityNotFoundException("회원을 조회할 수 없습니다.");
     private static final Supplier<IllegalArgumentException> WRONG_PASSWORD = () -> new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
     private static final Supplier<IllegalArgumentException> ILLEGAL_PASSWORD = () -> new IllegalArgumentException("부적절한 비밀번호입니다.");
+    private static final Supplier<EntityNotFoundException> VERIFICATION_NOT_FOUND = () -> new EntityNotFoundException("이메일 인증 정보를 찾을 수 없습니다.");
+    private static final Supplier<IllegalStateException> NOT_VERIFIED = () -> new IllegalStateException("인증되지 않은 이메일입니다.");
 
     private final UserRepository userRepository;
+    private final EmailVerificationRepository emailVerificationRepository;
     private final PasswordValidator passwordValidator;
     private final PasswordEncoder passwordEncoder;
     private final TokenProvider tokenProvider;
 
     @Transactional
-    public String updateMyPage(Long id, UserMyPageDto userMyPageDto) {
+    public String updateMyPage(long id, UserMyPageDto userMyPageDto) {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("User not found while updating MyPage Information."));
 
@@ -40,7 +46,7 @@ public class UserService {
     }
 
     @Transactional
-    public RefreshTokenResponseDto updatePassword(Long id, PasswordUpdateRequestDto requestDto) {
+    public RefreshTokenResponseDto updatePassword(long id, PasswordUpdateRequestDto requestDto) {
         GoodSpaceUser user = userRepository.findGoodSpaceUserById(id)
                 .orElseThrow(USER_NOT_FOUND);
         String rawPrevPassword = requestDto.prevPassword();
@@ -54,6 +60,20 @@ public class UserService {
 
         String encodedPassword = passwordEncoder.encode(rawNewPassword);
         user.updatePassword(encodedPassword);
+
+        return RefreshTokenResponseDto.builder()
+                .refreshToken(createNewRefreshToken(user))
+                .build();
+    }
+
+    @Transactional
+    public RefreshTokenResponseDto updateEmail(long id, EmailUpdateRequestDto requestDto) {
+        checkEmailVerification(requestDto.email());
+
+        User user = userRepository.findById(id)
+                .orElseThrow(USER_NOT_FOUND);
+
+        user.setEmail(requestDto.email());
 
         return RefreshTokenResponseDto.builder()
                 .refreshToken(createNewRefreshToken(user))
@@ -75,5 +95,16 @@ public class UserService {
         user.updateRefreshToken(refreshToken);
 
         return refreshToken;
+    }
+
+    private void checkEmailVerification(String email) {
+        EmailVerification emailVerification = emailVerificationRepository.findByEmail(email)
+                .orElseThrow(VERIFICATION_NOT_FOUND);
+
+        if (!emailVerification.isVerified()) {
+            throw NOT_VERIFIED.get();
+        }
+
+        emailVerificationRepository.delete(emailVerification);
     }
 }

--- a/src/test/java/goodspace/backend/user/service/UserServiceTest.java
+++ b/src/test/java/goodspace/backend/user/service/UserServiceTest.java
@@ -1,8 +1,13 @@
 package goodspace.backend.user.service;
 
+import goodspace.backend.email.entity.EmailVerification;
+import goodspace.backend.email.repository.EmailVerificationRepository;
+import goodspace.backend.fixture.EmailVerificationFixture;
 import goodspace.backend.fixture.GoodSpaceUserFixture;
 import goodspace.backend.user.domain.GoodSpaceUser;
+import goodspace.backend.user.dto.EmailUpdateRequestDto;
 import goodspace.backend.user.dto.PasswordUpdateRequestDto;
+import goodspace.backend.user.dto.RefreshTokenResponseDto;
 import goodspace.backend.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -14,11 +19,13 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional
 class UserServiceTest {
     static final String DEFAULT_PASSWORD = "HelloPassword1!";
+    static final String DEFAULT_REFRESH_TOKEN = "defaultRefreshToken";
 
     @Autowired
     UserService userService;
@@ -26,13 +33,21 @@ class UserServiceTest {
     UserRepository userRepository;
     @Autowired
     PasswordEncoder passwordEncoder;
+    @Autowired
+    EmailVerificationRepository emailVerificationRepository;
 
     GoodSpaceUser user;
+    EmailVerification verifiedEmail;
+    EmailVerification notVerifiedEmail;
 
     @BeforeEach
     void resetEntities() {
         user = userRepository.save(GoodSpaceUserFixture.DEFAULT.getInstance());
         user.updatePassword(passwordEncoder.encode(DEFAULT_PASSWORD));
+        user.updateRefreshToken(DEFAULT_REFRESH_TOKEN);
+
+        verifiedEmail = emailVerificationRepository.save(EmailVerificationFixture.VERIFIED.getInstance());
+        notVerifiedEmail = emailVerificationRepository.save(EmailVerificationFixture.NOT_VERIFIED.getInstance());
     }
 
     @Nested
@@ -52,6 +67,50 @@ class UserServiceTest {
 
             // then
             assertThat(isSamePassword(newPassword, user.getPassword())).isTrue();
+        }
+    }
+
+    @Nested
+    class updateEmail {
+        @Test
+        @DisplayName("이메일을 변경한다")
+        void changeEmail() {
+            // given
+            EmailUpdateRequestDto requestDto = EmailUpdateRequestDto.builder()
+                    .email(verifiedEmail.getEmail())
+                    .build();
+
+            // when
+            userService.updateEmail(user.getId(), requestDto);
+
+            // then
+            assertThat(user.getEmail()).isEqualTo(verifiedEmail.getEmail());
+        }
+
+        @Test
+        @DisplayName("리프레쉬 토큰을 새로 발급한다")
+        void reissueRefreshToken() {
+            // given
+            EmailUpdateRequestDto requestDto = EmailUpdateRequestDto.builder()
+                    .email(verifiedEmail.getEmail())
+                    .build();
+
+            // when
+            RefreshTokenResponseDto tokenDto = userService.updateEmail(user.getId(), requestDto);
+
+            // then
+            assertThat(tokenDto.refreshToken()).isNotEqualTo(DEFAULT_REFRESH_TOKEN);
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 이메일이라면 예외가 발생한다")
+        void ifNotVerifiedEmailThenThrowException() {
+            EmailUpdateRequestDto requestDto = EmailUpdateRequestDto.builder()
+                    .email(notVerifiedEmail.getEmail())
+                    .build();
+
+            assertThatThrownBy(() -> userService.updateEmail(user.getId(), requestDto))
+                    .isInstanceOf(IllegalStateException.class);
         }
     }
 


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
이메일 수정 API를 구현했습니다.
`UserController`에 Swagger-UI 명세를 추가했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#76
