### PR TITLE
[fix/#84] 일반 데이터들은 `@ReuqestParam`을 통해 받아오도록 수정

### DIFF
--- a/src/main/java/goodspace/backend/admin/controller/ClientManageController.java
+++ b/src/main/java/goodspace/backend/admin/controller/ClientManageController.java
@@ -54,11 +54,11 @@ public class ClientManageController {
             description = "새로운 클라이언트를 생성합니다."
     )
     public ResponseEntity<Void> createClient(
-            @RequestPart("name") String name,
+            @RequestParam String name,
+            @RequestParam String introduction,
+            @RequestParam ClientType clientType,
             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
-            @RequestPart(value = "backgroundImage", required = false) MultipartFile backgroundImage,
-            @RequestPart("introduction") String introduction,
-            @RequestPart("clientType") ClientType clientType
+            @RequestPart(value = "backgroundImage", required = false) MultipartFile backgroundImage
     ) {
         clientManageService.register(ClientRegisterRequestDto.builder()
                 .name(name)
@@ -77,14 +77,14 @@ public class ClientManageController {
             description = "클라이언트의 정보를 수정합니다."
     )
     public ResponseEntity<Void> updateClient(
-            @RequestPart("id") Long id,
-            @RequestPart("name") String name,
+            @RequestParam Long id,
+            @RequestParam String name,
+            @RequestParam String introduction,
+            @RequestParam ClientType clientType,
+            @RequestParam RegisterStatus status,
             @RequestPart(value = "profileImage", required = false) MultipartFile profileImage,
-            @RequestPart(value = "backgroundImage", required = false) MultipartFile backgroundImage,
-            @RequestPart("introduction") String introduction,
-            @RequestPart("clientType") ClientType clientType,
-            @RequestPart("status") RegisterStatus status
-    ) {
+            @RequestPart(value = "backgroundImage", required = false) MultipartFile backgroundImage
+            ) {
         clientManageService.update(ClientUpdateRequestDto.builder()
                 .id(id)
                 .name(name)

--- a/src/main/java/goodspace/backend/admin/controller/ItemImageManageController.java
+++ b/src/main/java/goodspace/backend/admin/controller/ItemImageManageController.java
@@ -40,8 +40,8 @@ public class ItemImageManageController {
             description = "상품에 이미지를 추가합니다."
     )
     public ResponseEntity<Void> addImage(
-            @RequestPart("clientId") Long clientId,
-            @RequestPart("itemId") Long itemId,
+            @RequestParam Long clientId,
+            @RequestParam Long itemId,
             @RequestPart("image") MultipartFile image
     ) {
         itemImageManageService.register(ItemImageRegisterRequestDto.builder()
@@ -59,8 +59,8 @@ public class ItemImageManageController {
             description = "상품에 타이틀 이미지를 추가합니다."
     )
     public ResponseEntity<Void> addTitleImage(
-            @RequestPart("clientId") Long clientId,
-            @RequestPart("itemId") Long itemId,
+            @RequestParam Long clientId,
+            @RequestParam Long itemId,
             @RequestPart("image") MultipartFile image
     ) {
         itemImageManageService.registerTitleImage(ItemImageRegisterRequestDto.builder()
@@ -78,7 +78,7 @@ public class ItemImageManageController {
             description = "상품의 타이틀 이미지를 수정합니다."
     )
     public ResponseEntity<Void> updateTitleImage(
-            @RequestPart("itemId") Long itemId,
+            @RequestParam Long itemId,
             @RequestPart("image") MultipartFile image
     ) {
         itemImageManageService.updateTitleImage(TitleImageUpdateRequestDto.builder()


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
관리자 페이지 API에서 MutlipartFile을 제외한 나머지 데이터들은 `@RequestParam`을 사용해 받아오도록 수정했습니다.
클라이언트가 보내는 값을 `form-data` 형식으로 매핑하지 못하는 문제를 해결하기 위해 변경했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#84 
