### PR TITLE
[fix] 엑세스 토큰 재발급 API의 액션 메서드에 @RequestBody가 누락된 문제 해결

### DIFF
--- a/src/main/java/goodspace/backend/authorization/controller/AccessTokenReissueController.java
+++ b/src/main/java/goodspace/backend/authorization/controller/AccessTokenReissueController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,7 +27,7 @@ public class AccessTokenReissueController {
             summary = "토큰 재발급",
             description = "리프레쉬 토큰을 통해 엑세스 토큰을 재발급합니다"
     )
-    public ResponseEntity<AccessTokenResponseDto> reissueAccessToken(AccessTokenReissueRequestDto requestDto) {
+    public ResponseEntity<AccessTokenResponseDto> reissueAccessToken(@RequestBody AccessTokenReissueRequestDto requestDto) {
         AccessTokenResponseDto responseDto = accessTokenService.reissue(requestDto);
 
         return ResponseEntity.ok(responseDto);


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
엑세스 토큰 재발급 API에 `@RequestBody` 어노태이션이 누락된 문제를 해결했습니다.
