### PR TITLE
[feat/#105] 장바구니 CRUD 구현

### DIFF
--- a/src/main/java/goodspace/backend/cart/controller/CartItemController.java
+++ b/src/main/java/goodspace/backend/cart/controller/CartItemController.java
@@ -1,0 +1,83 @@
+package goodspace.backend.cart.controller;
+
+import goodspace.backend.cart.dto.CartItemAddRequestDto;
+import goodspace.backend.cart.dto.CartItemInfoResponseDto;
+import goodspace.backend.cart.dto.CartItemUpdateRequestDto;
+import goodspace.backend.cart.service.CartItemService;
+import goodspace.backend.global.principal.PrincipalUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(
+        name = "장바구니 API",
+        description = "장바구니 관리 관련 기능"
+)
+public class CartItemController {
+    private final CartItemService cartItemService;
+    private final PrincipalUtil principalUtil;
+
+    @GetMapping
+    @Operation(
+            summary = "장바구니 상품 조회",
+            description = "해당 회원의 모든 장바구니 상품을 조회합니다."
+    )
+    public ResponseEntity<List<CartItemInfoResponseDto>> findCartItems(Principal principal) {
+        long userId = principalUtil.findIdFromPrincipal(principal);
+        List<CartItemInfoResponseDto> response = cartItemService.getCartItems(userId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping
+    @Operation(
+            summary = "장바구니 상품 추가",
+            description = "장바구니 상품을 추가합니다"
+    )
+    public ResponseEntity<Void> addCartItem(
+            Principal principal,
+            @RequestBody CartItemAddRequestDto requestDto
+    ) {
+        long userId = principalUtil.findIdFromPrincipal(principal);
+        cartItemService.addCartItem(userId, requestDto);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping
+    @Operation(
+            summary = "장바구니 상품 수정",
+            description = "장바구니 상품의 정보를 수정합니다(수량 변경용)"
+    )
+    public ResponseEntity<Void> updateCartItem(
+            Principal principal,
+            @RequestBody CartItemUpdateRequestDto requestDto
+    ) {
+        long userId = principalUtil.findIdFromPrincipal(principal);
+        cartItemService.updateCartItem(userId, requestDto);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping
+    @Operation(
+            summary = "장바구니 상품 제거",
+            description = "장바구니 상품을 제거합니다."
+    )
+    public ResponseEntity<Void> removeCartItem(
+            Principal principal,
+            @RequestParam Long cartItemId
+    ) {
+        long userId = principalUtil.findIdFromPrincipal(principal);
+        cartItemService.removeCartItem(userId, cartItemId);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/goodspace/backend/cart/dto/CartItemAddRequestDto.java
+++ b/src/main/java/goodspace/backend/cart/dto/CartItemAddRequestDto.java
@@ -1,0 +1,10 @@
+package goodspace.backend.cart.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CartItemAddRequestDto(
+        Long itemId,
+        Integer quantity
+) {
+}

--- a/src/main/java/goodspace/backend/cart/dto/CartItemInfoResponseDto.java
+++ b/src/main/java/goodspace/backend/cart/dto/CartItemInfoResponseDto.java
@@ -1,0 +1,35 @@
+package goodspace.backend.cart.dto;
+
+import goodspace.backend.global.domain.Item;
+import goodspace.backend.user.domain.CartItem;
+import lombok.Builder;
+
+@Builder
+public record CartItemInfoResponseDto(
+    Long id,
+    Integer quantity,
+    ItemDto item
+) {
+    public static CartItemInfoResponseDto from(CartItem cartItem) {
+        return CartItemInfoResponseDto.builder()
+                .id(cartItem.getId())
+                .quantity(cartItem.getQuantity())
+                .item(ItemDto.from(cartItem.getItem()))
+                .build();
+    }
+
+    @Builder
+    public record ItemDto(
+            String name,
+            Integer price,
+            String titleImageUrl
+    ) {
+        public static ItemDto from(Item item) {
+            return ItemDto.builder()
+                    .name(item.getName())
+                    .price(item.getPrice())
+                    .titleImageUrl(item.getTitleImageUrl())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/goodspace/backend/cart/dto/CartItemUpdateRequestDto.java
+++ b/src/main/java/goodspace/backend/cart/dto/CartItemUpdateRequestDto.java
@@ -1,0 +1,10 @@
+package goodspace.backend.cart.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CartItemUpdateRequestDto(
+        Long cartItemId,
+        Integer quantity
+) {
+}

--- a/src/main/java/goodspace/backend/cart/service/CartItemService.java
+++ b/src/main/java/goodspace/backend/cart/service/CartItemService.java
@@ -1,0 +1,17 @@
+package goodspace.backend.cart.service;
+
+import goodspace.backend.cart.dto.CartItemAddRequestDto;
+import goodspace.backend.cart.dto.CartItemInfoResponseDto;
+import goodspace.backend.cart.dto.CartItemUpdateRequestDto;
+
+import java.util.List;
+
+public interface CartItemService {
+    List<CartItemInfoResponseDto> getCartItems(long userId);
+
+    void addCartItem(long userId, CartItemAddRequestDto requestDto);
+
+    void updateCartItem(long userId, CartItemUpdateRequestDto requestDto);
+
+    void removeCartItem(long userId, long cartItemId);
+}

--- a/src/main/java/goodspace/backend/cart/service/CartItemServiceImpl.java
+++ b/src/main/java/goodspace/backend/cart/service/CartItemServiceImpl.java
@@ -1,0 +1,87 @@
+package goodspace.backend.cart.service;
+
+import goodspace.backend.cart.dto.CartItemAddRequestDto;
+import goodspace.backend.cart.dto.CartItemInfoResponseDto;
+import goodspace.backend.cart.dto.CartItemUpdateRequestDto;
+import goodspace.backend.global.domain.Item;
+import goodspace.backend.global.repository.ItemRepository;
+import goodspace.backend.user.domain.User;
+import goodspace.backend.user.domain.CartItem;
+import goodspace.backend.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+@Service
+@RequiredArgsConstructor
+public class CartItemServiceImpl implements CartItemService {
+    private static final Supplier<EntityNotFoundException> USER_NOT_FOUND = () -> new EntityNotFoundException("회원을 조회하지 못했습니다.");
+    private static final Supplier<EntityNotFoundException> CART_ITEM_NOT_FOUND = () -> new EntityNotFoundException("장바구니 상품을 조회하지 못했습니다.");
+    private static final Supplier<EntityNotFoundException> ITEM_NOT_FOUND = () -> new EntityNotFoundException("상품을 조회하지 못했습니다.");
+    private static final Supplier<IllegalArgumentException> ILLEGAL_QUANTITY = () -> new IllegalArgumentException("수량은 0이하일 수 없습니다.");
+
+    private final UserRepository userRepository;
+    private final ItemRepository itemRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CartItemInfoResponseDto> getCartItems(long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(USER_NOT_FOUND);
+
+        return user.getCartItems().stream()
+                .map(CartItemInfoResponseDto::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public void removeCartItem(long userId, long cartItemId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(USER_NOT_FOUND);
+        CartItem cartItem = findCartItemById(user, cartItemId);
+
+        user.removeCartItem(cartItem);
+    }
+
+    @Override
+    @Transactional
+    public void addCartItem(long userId, CartItemAddRequestDto requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(USER_NOT_FOUND);
+        Item item = itemRepository.findById(requestDto.itemId())
+                .orElseThrow(ITEM_NOT_FOUND);
+
+        CartItem cartItem = CartItem.builder()
+                .user(user)
+                .item(item)
+                .quantity(requestDto.quantity())
+                .build();
+        user.addCartItem(cartItem);
+    }
+
+    @Override
+    @Transactional
+    public void updateCartItem(long userId, CartItemUpdateRequestDto requestDto) {
+        if (requestDto.quantity() < 0) {
+            throw ILLEGAL_QUANTITY.get();
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(USER_NOT_FOUND);
+        CartItem cartItem = findCartItemById(user, requestDto.cartItemId());
+
+        cartItem.updateQuantity(requestDto.quantity());
+    }
+
+    private CartItem findCartItemById(User user, long cartItemId) {
+        return user.getCartItems().stream()
+                .filter(item -> item.getId().equals(cartItemId))
+                .findAny()
+                .orElseThrow(CART_ITEM_NOT_FOUND);
+    }
+}

--- a/src/main/java/goodspace/backend/global/domain/ItemImage.java
+++ b/src/main/java/goodspace/backend/global/domain/ItemImage.java
@@ -11,7 +11,7 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ItemImage extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Setter
     private String imageUrl;

--- a/src/main/java/goodspace/backend/global/principal/PrincipalUtil.java
+++ b/src/main/java/goodspace/backend/global/principal/PrincipalUtil.java
@@ -1,0 +1,12 @@
+package goodspace.backend.global.principal;
+
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+
+@Component
+public class PrincipalUtil {
+    public long findIdFromPrincipal(Principal principal) {
+        return Long.parseLong(principal.getName());
+    }
+}

--- a/src/main/java/goodspace/backend/global/repository/CartItemRepository.java
+++ b/src/main/java/goodspace/backend/global/repository/CartItemRepository.java
@@ -1,0 +1,7 @@
+package goodspace.backend.global.repository;
+
+import goodspace.backend.user.domain.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+}

--- a/src/main/java/goodspace/backend/qna/domain/Question.java
+++ b/src/main/java/goodspace/backend/qna/domain/Question.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 @NoArgsConstructor
 public class Question extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String title;
     private String content;

--- a/src/main/java/goodspace/backend/qna/domain/QuestionFile.java
+++ b/src/main/java/goodspace/backend/qna/domain/QuestionFile.java
@@ -13,7 +13,7 @@ import lombok.experimental.SuperBuilder;
 @Getter
 public class QuestionFile extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Lob

--- a/src/main/java/goodspace/backend/user/domain/CartItem.java
+++ b/src/main/java/goodspace/backend/user/domain/CartItem.java
@@ -16,7 +16,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 public class CartItem extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private Integer quantity;

--- a/src/main/java/goodspace/backend/user/domain/CartItem.java
+++ b/src/main/java/goodspace/backend/user/domain/CartItem.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Getter
@@ -13,27 +14,24 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder
-public class UserCartItem extends BaseEntity {
+public class CartItem extends BaseEntity {
     @Id
     @GeneratedValue
     private Long id;
 
     private Integer quantity;
-    private Integer amount;
 
     @ManyToOne
     @JoinColumn(name = "item_id")
+    @Setter
     private Item item;
 
     @ManyToOne
     @JoinColumn(name = "user_id")
+    @Setter
     private User user;
 
-    @PrePersist
-    @PreUpdate
-    public void updateAmount() {
-        if (item != null){
-            this.amount = item.getPrice() * this.quantity;
-        }
+    public void updateQuantity(Integer quantity) {
+        this.quantity = quantity;
     }
 }

--- a/src/main/java/goodspace/backend/user/domain/User.java
+++ b/src/main/java/goodspace/backend/user/domain/User.java
@@ -23,7 +23,7 @@ import java.util.List;
 @Table(name = "`user`")
 public abstract class User extends BaseEntity {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     private Integer dateOfBirth;
@@ -41,7 +41,8 @@ public abstract class User extends BaseEntity {
     private final List<Order> orders = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<UserCartItem> userCartItems = new ArrayList<>();
+    @Builder.Default
+    private List<CartItem> cartItems = new ArrayList<>();
 
     // TODO 이후에 이름을 questions로 수정
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
@@ -99,5 +100,18 @@ public abstract class User extends BaseEntity {
     public void addQuestion(Question question) {
         this.question.add(question);
         question.setUser(this);
+    }
+
+    /**
+     * User - CartItem 연관관계 편의 메서드
+     */
+    public void addCartItem(CartItem cartItem) {
+        cartItems.add(cartItem);
+        cartItem.setUser(this);
+    }
+
+    public void removeCartItem(CartItem cartItem) {
+        cartItems.remove(cartItem);
+        cartItem.setUser(null);
     }
 }

--- a/src/test/java/goodspace/backend/cart/service/CartItemServiceTest.java
+++ b/src/test/java/goodspace/backend/cart/service/CartItemServiceTest.java
@@ -1,0 +1,186 @@
+package goodspace.backend.cart.service;
+
+import goodspace.backend.cart.dto.CartItemAddRequestDto;
+import goodspace.backend.cart.dto.CartItemInfoResponseDto;
+import goodspace.backend.cart.dto.CartItemUpdateRequestDto;
+import goodspace.backend.fixture.GoodSpaceUserFixture;
+import goodspace.backend.fixture.ItemFixture;
+import goodspace.backend.global.domain.Item;
+import goodspace.backend.global.repository.CartItemRepository;
+import goodspace.backend.global.repository.ItemRepository;
+import goodspace.backend.user.domain.CartItem;
+import goodspace.backend.user.domain.User;
+import goodspace.backend.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class CartItemServiceTest {
+    static final Supplier<EntityNotFoundException> DTO_NOT_FOUND = () -> new EntityNotFoundException("DTO를 조회할 수 없습니다.");
+    static final int DEFAULT_QUANTITY = 5;
+    static final int NEW_QUANTITY = 9474747;
+
+    @Autowired
+    CartItemService cartItemService;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    ItemRepository itemRepository;
+    @Autowired
+    CartItemRepository cartItemRepository;
+
+    User user;
+    User emptyCartUser;
+    Item itemA;
+    Item itemB;
+    CartItem cartItemA;
+    CartItem cartItemB;
+    List<CartItem> existCartItems;
+
+    @BeforeEach
+    void resetEntities() {
+        user = userRepository.save(GoodSpaceUserFixture.A.getInstance());
+        emptyCartUser = userRepository.save(GoodSpaceUserFixture.B.getInstance());
+
+        itemA = itemRepository.save(ItemFixture.PUBLIC_A.getInstance());
+        itemB = itemRepository.save(ItemFixture.PUBLIC_B.getInstance());
+
+        cartItemA = cartItemRepository.save(CartItem.builder()
+                .user(user)
+                .item(itemA)
+                .quantity(DEFAULT_QUANTITY)
+                .build());
+        cartItemB = cartItemRepository.save(CartItem.builder()
+                .user(user)
+                .item(itemB)
+                .quantity(DEFAULT_QUANTITY)
+                .build());
+
+        user.addCartItem(cartItemA);
+        user.addCartItem(cartItemB);
+        existCartItems = List.of(cartItemA, cartItemB);
+    }
+
+    @Nested
+    class getCartItems {
+        @Test
+        @DisplayName("회원의 모든 장바구니 상품을 조회한다")
+        void getCartItemsOfUser() {
+            List<CartItemInfoResponseDto> responseDtos = cartItemService.getCartItems(user.getId());
+
+            assertThat(responseDtos.size()).isEqualTo(existCartItems.size());
+
+            for (CartItem existCartItem : existCartItems) {
+                CartItemInfoResponseDto responseDto = findDtoById(existCartItem.getId(), responseDtos);
+
+                assertThat(isEqual(existCartItem, responseDto)).isTrue();
+            }
+        }
+    }
+
+    @Nested
+    class addCartItem {
+        @Test
+        @DisplayName("새로운 장바구니 상품을 추가한다")
+        void addNewCartItem() {
+            // given
+            CartItemAddRequestDto requestDto = CartItemAddRequestDto.builder()
+                    .itemId(itemA.getId())
+                    .quantity(DEFAULT_QUANTITY)
+                    .build();
+
+            // when
+            cartItemService.addCartItem(emptyCartUser.getId(), requestDto);
+
+            // then
+            List<CartItem> cartItems = emptyCartUser.getCartItems();
+            assertThat(cartItems.size()).isEqualTo(1);
+
+            CartItem cartItem = cartItems.get(0);
+            assertThat(cartItem.getItem()).isEqualTo(itemA);
+            assertThat(cartItem.getUser()).isEqualTo(emptyCartUser);
+        }
+    }
+
+    @Nested
+    class updateCartItem {
+        @Test
+        @DisplayName("장바구니 상품의 정보(수량)를 수정한다")
+        void updateInfoOfCartItem() {
+            // given
+            CartItemUpdateRequestDto requestDto = CartItemUpdateRequestDto.builder()
+                    .cartItemId(cartItemA.getId())
+                    .quantity(NEW_QUANTITY)
+                    .build();
+
+            // when
+            cartItemService.updateCartItem(user.getId(), requestDto);
+
+            // then
+            assertThat(cartItemA.getQuantity()).isEqualTo(NEW_QUANTITY);
+        }
+
+        @ParameterizedTest
+        @DisplayName("수량이 음수면 예외가 발생한다")
+        @ValueSource(ints = {Integer.MIN_VALUE, -9999, -1})
+        void updateInfoOfCartItem(int negativeQuantity) {
+            CartItemUpdateRequestDto requestDto = CartItemUpdateRequestDto.builder()
+                    .cartItemId(cartItemA.getId())
+                    .quantity(negativeQuantity)
+                    .build();
+
+            assertThatThrownBy(() -> cartItemService.updateCartItem(user.getId(), requestDto))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Nested
+    class removeCartItem {
+        @Test
+        @DisplayName("회원의 장바구니 상품을 제거한다")
+        void removeCartItemOfUser() {
+            List<CartItem> cartItems = user.getCartItems();
+            long existAmountOfCartItem = cartItems.size();
+
+            cartItemService.removeCartItem(user.getId(), cartItemA.getId());
+
+            long currentAmountOfCartITem = cartItems.size();
+            assertThat(currentAmountOfCartITem).isEqualTo(existAmountOfCartItem - 1);
+            assertThat(cartItems.contains(cartItemA)).isFalse();
+        }
+    }
+
+    private CartItemInfoResponseDto findDtoById(long id, List<CartItemInfoResponseDto> dtos) {
+        return dtos.stream()
+                .filter(dto -> dto.id().equals(id))
+                .findAny()
+                .orElseThrow(DTO_NOT_FOUND);
+    }
+
+    private boolean isEqual(CartItem cartItem, CartItemInfoResponseDto dto) {
+        return cartItem.getId().equals(dto.id()) &&
+                cartItem.getQuantity().equals(dto.quantity()) &&
+                isEqual(cartItem.getItem(), dto.item());
+    }
+
+    private boolean isEqual(Item item, CartItemInfoResponseDto.ItemDto dto) {
+        return item.getName().equals(dto.name()) &&
+                item.getPrice().equals(dto.price()) &&
+                Objects.equals(item.getTitleImageUrl(), dto.titleImageUrl());
+    }
+}

--- a/src/test/java/goodspace/backend/fixture/GoodSpaceUserFixture.java
+++ b/src/test/java/goodspace/backend/fixture/GoodSpaceUserFixture.java
@@ -8,6 +8,16 @@ public enum GoodSpaceUserFixture {
         "default@email.com",
             "HelloWorldJava1!",
             Role.USER
+    ),
+    A(
+            "A@email.com",
+            "HelloWorldJava1!a",
+            Role.USER
+    ),
+    B(
+            "B@email.com",
+            "HelloWorldJava1!b",
+            Role.USER
     );
 
     private final String email;


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
장바구니 CRUD API를 구현했습니다.
모든 엔티티의 기본키 생성 전략을 IDENTITY로 지정했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#105 
