### PR TITLE
[feat/#128] 종류/카테고리 관련 API 구현

### DIFF
--- a/src/main/java/goodspace/backend/client/domain/ClientType.java
+++ b/src/main/java/goodspace/backend/client/domain/ClientType.java
@@ -1,5 +1,15 @@
 package goodspace.backend.client.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum ClientType {
-    CREATOR, INFLUENCER
+    CREATOR("크리에이터"),
+    INFLUENCER("인플루언서");
+
+    private final String korean;
+
+    ClientType(String korean) {
+        this.korean = korean;
+    }
 }

--- a/src/main/java/goodspace/backend/client/domain/RegisterStatus.java
+++ b/src/main/java/goodspace/backend/client/domain/RegisterStatus.java
@@ -1,5 +1,15 @@
 package goodspace.backend.client.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum RegisterStatus {
-    PRIVATE, PUBLIC
+    PRIVATE("비공개"),
+    PUBLIC("공개");
+
+    private final String korean;
+
+    RegisterStatus(String korean) {
+        this.korean = korean;
+    }
 }

--- a/src/main/java/goodspace/backend/global/security/SecurityConfig.java
+++ b/src/main/java/goodspace/backend/global/security/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
                         .requestMatchers("/orderTest/**", "/payment/**","/css/**", "/js/**", "/images/**", "/stylesheets/**","/api/**", "/api/qna").permitAll()
                         .requestMatchers("/client/**").permitAll() // 클라이언트 상품 페이지 관련
                         .requestMatchers("/stylesheets/**","/api/**").permitAll()
+                        .requestMatchers("/meta/**").permitAll() // 카테고리/타입 관련
                         .requestMatchers("/admin/**").hasRole("ADMIN") // 관리자 전용 API
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/goodspace/backend/meta/controller/MetaController.java
+++ b/src/main/java/goodspace/backend/meta/controller/MetaController.java
@@ -1,0 +1,90 @@
+package goodspace.backend.meta.controller;
+
+import goodspace.backend.meta.dto.*;
+import goodspace.backend.meta.service.MetaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/meta")
+@RequiredArgsConstructor
+@Tag(
+        name = "Meta API",
+        description = "상수로 관리하는 타입/카테고리 관련 기능"
+)
+public class MetaController {
+    private final MetaService metaService;
+
+    @GetMapping("/client-type")
+    @Operation(
+            summary = "클라이언트 종류",
+            description = "모든 Client Type을 반환합니다."
+    )
+    public ResponseEntity<List<ClientTypeDto>> getClientTypes() {
+        List<ClientTypeDto> response = metaService.getClientTypes();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/oauth-type")
+    @Operation(
+            summary = "OAuth 종류",
+            description = "모든 OAuth Type을 반환합니다."
+    )
+    public ResponseEntity<List<OAuthTypeDto>> getOAuthTypes() {
+        List<OAuthTypeDto> response = metaService.getOauthTypes();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/order-status")
+    @Operation(
+            summary = "주문 상태",
+            description = "모든 Order Status를 반환합니다."
+    )
+    public ResponseEntity<List<OrderStatusDto>> getOrderStatuses() {
+        List<OrderStatusDto> response = metaService.getOrderStatuses();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/question-status")
+    @Operation(
+            summary = "문의 상태",
+            description = "모든 Question Status를 반환합니다."
+    )
+    public ResponseEntity<List<QuestionStatusDto>> getQuestionStatuses() {
+        List<QuestionStatusDto> response = metaService.getQuestionStatuses();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/question-type")
+    @Operation(
+            summary = "문의 유형",
+            description = "모든 Question Type을 반환합니다."
+    )
+    public ResponseEntity<List<QuestionTypeDto>> getQuestionTypes() {
+        List<QuestionTypeDto> response = metaService.getQuestionTypes();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/register-status")
+    @Operation(
+            summary = "등록 상태",
+            description = "모든 Register Status를 반환합니다."
+    )
+    public ResponseEntity<List<RegisterStatusDto>> getRegisterStatuses() {
+        List<RegisterStatusDto> response = metaService.getRegisterStatuses();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/goodspace/backend/meta/dto/ClientTypeDto.java
+++ b/src/main/java/goodspace/backend/meta/dto/ClientTypeDto.java
@@ -1,0 +1,17 @@
+package goodspace.backend.meta.dto;
+
+import goodspace.backend.client.domain.ClientType;
+import lombok.Builder;
+
+@Builder
+public record ClientTypeDto(
+        String name,
+        String korean
+) {
+    public static ClientTypeDto from(ClientType clientType) {
+        return ClientTypeDto.builder()
+                .name(clientType.name())
+                .korean(clientType.getKorean())
+                .build();
+    }
+}

--- a/src/main/java/goodspace/backend/meta/dto/OAuthTypeDto.java
+++ b/src/main/java/goodspace/backend/meta/dto/OAuthTypeDto.java
@@ -1,0 +1,17 @@
+package goodspace.backend.meta.dto;
+
+import goodspace.backend.user.domain.OAuthType;
+import lombok.Builder;
+
+@Builder
+public record OAuthTypeDto(
+        String name,
+        String korean
+) {
+    public static OAuthTypeDto from(OAuthType oauthType) {
+        return OAuthTypeDto.builder()
+                .name(oauthType.name())
+                .korean(oauthType.getKorean())
+                .build();
+    }
+}

--- a/src/main/java/goodspace/backend/meta/dto/OrderStatusDto.java
+++ b/src/main/java/goodspace/backend/meta/dto/OrderStatusDto.java
@@ -1,0 +1,17 @@
+package goodspace.backend.meta.dto;
+
+import goodspace.backend.order.domain.OrderStatus;
+import lombok.Builder;
+
+@Builder
+public record OrderStatusDto(
+        String name,
+        String korean
+) {
+    public static OrderStatusDto from(OrderStatus orderStatus) {
+        return OrderStatusDto.builder()
+                .name(orderStatus.name())
+                .korean(orderStatus.getKorean())
+                .build();
+    }
+}

--- a/src/main/java/goodspace/backend/meta/dto/QuestionStatusDto.java
+++ b/src/main/java/goodspace/backend/meta/dto/QuestionStatusDto.java
@@ -1,0 +1,17 @@
+package goodspace.backend.meta.dto;
+
+import goodspace.backend.qna.domain.QuestionStatus;
+import lombok.Builder;
+
+@Builder
+public record QuestionStatusDto(
+        String name,
+        String korean
+) {
+    public static QuestionStatusDto from(QuestionStatus questionStatus) {
+        return QuestionStatusDto.builder()
+                .name(questionStatus.name())
+                .korean(questionStatus.getKorean())
+                .build();
+    }
+}

--- a/src/main/java/goodspace/backend/meta/dto/QuestionTypeDto.java
+++ b/src/main/java/goodspace/backend/meta/dto/QuestionTypeDto.java
@@ -1,0 +1,17 @@
+package goodspace.backend.meta.dto;
+
+import goodspace.backend.qna.domain.QuestionType;
+import lombok.Builder;
+
+@Builder
+public record QuestionTypeDto(
+        String name,
+        String korean
+) {
+    public static QuestionTypeDto from(QuestionType questionType) {
+        return QuestionTypeDto.builder()
+                .name(questionType.name())
+                .korean(questionType.getKorean())
+                .build();
+    }
+}

--- a/src/main/java/goodspace/backend/meta/dto/RegisterStatusDto.java
+++ b/src/main/java/goodspace/backend/meta/dto/RegisterStatusDto.java
@@ -1,0 +1,17 @@
+package goodspace.backend.meta.dto;
+
+import goodspace.backend.client.domain.RegisterStatus;
+import lombok.Builder;
+
+@Builder
+public record RegisterStatusDto(
+        String name,
+        String korean
+) {
+    public static RegisterStatusDto from(RegisterStatus registerStatus) {
+        return RegisterStatusDto.builder()
+                .name(registerStatus.name())
+                .korean(registerStatus.getKorean())
+                .build();
+    }
+}

--- a/src/main/java/goodspace/backend/meta/service/MetaService.java
+++ b/src/main/java/goodspace/backend/meta/service/MetaService.java
@@ -1,0 +1,19 @@
+package goodspace.backend.meta.service;
+
+import goodspace.backend.meta.dto.*;
+
+import java.util.List;
+
+public interface MetaService {
+    List<ClientTypeDto> getClientTypes();
+
+    List<OAuthTypeDto> getOauthTypes();
+
+    List<OrderStatusDto> getOrderStatuses();
+
+    List<QuestionStatusDto> getQuestionStatuses();
+
+    List<QuestionTypeDto> getQuestionTypes();
+
+    List<RegisterStatusDto> getRegisterStatuses();
+}

--- a/src/main/java/goodspace/backend/meta/service/MetaServiceImpl.java
+++ b/src/main/java/goodspace/backend/meta/service/MetaServiceImpl.java
@@ -1,0 +1,58 @@
+package goodspace.backend.meta.service;
+
+import goodspace.backend.client.domain.ClientType;
+import goodspace.backend.client.domain.RegisterStatus;
+import goodspace.backend.meta.dto.*;
+import goodspace.backend.order.domain.OrderStatus;
+import goodspace.backend.qna.domain.QuestionStatus;
+import goodspace.backend.qna.domain.QuestionType;
+import goodspace.backend.user.domain.OAuthType;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+public class MetaServiceImpl implements MetaService {
+    @Override
+    public List<ClientTypeDto> getClientTypes() {
+        return Arrays.stream(ClientType.values())
+                .map(ClientTypeDto::from)
+                .toList();
+    }
+
+    @Override
+    public List<OAuthTypeDto> getOauthTypes() {
+        return Arrays.stream(OAuthType.values())
+                .map(OAuthTypeDto::from)
+                .toList();
+    }
+
+    @Override
+    public List<OrderStatusDto> getOrderStatuses() {
+        return Arrays.stream(OrderStatus.values())
+                .map(OrderStatusDto::from)
+                .toList();
+    }
+
+    @Override
+    public List<QuestionStatusDto> getQuestionStatuses() {
+        return Arrays.stream(QuestionStatus.values())
+                .map(QuestionStatusDto::from)
+                .toList();
+    }
+
+    @Override
+    public List<QuestionTypeDto> getQuestionTypes() {
+        return Arrays.stream(QuestionType.values())
+                .map(QuestionTypeDto::from)
+                .toList();
+    }
+
+    @Override
+    public List<RegisterStatusDto> getRegisterStatuses() {
+        return Arrays.stream(RegisterStatus.values())
+                .map(RegisterStatusDto::from)
+                .toList();
+    }
+}

--- a/src/main/java/goodspace/backend/order/domain/OrderStatus.java
+++ b/src/main/java/goodspace/backend/order/domain/OrderStatus.java
@@ -1,11 +1,20 @@
 package goodspace.backend.order.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum OrderStatus {
-    PAYMENT_CONFIRMED,   // 결제 확인
-    PREPARING_PRODUCT,   // 제작 준비중
-    MAKING_PRODUCT,      // 제작 중
-    PREPARING_DELIVERY,  // 배송 준비중
-    SHIPPING,            // 배송중
-    DELIVERED,            // 배송완료
-    CANCELED
+    PAYMENT_CONFIRMED("결제 확인"),
+    PREPARING_PRODUCT("제작 준비중"),
+    MAKING_PRODUCT("제작 중"),
+    PREPARING_DELIVERY("배송 준비중"),
+    SHIPPING("배송중"),
+    DELIVERED("배송완료"),
+    CANCELED("취소됨");
+
+    private final String korean;
+
+    OrderStatus(String korean) {
+        this.korean = korean;
+    }
 }

--- a/src/main/java/goodspace/backend/qna/domain/QuestionStatus.java
+++ b/src/main/java/goodspace/backend/qna/domain/QuestionStatus.java
@@ -1,5 +1,15 @@
 package goodspace.backend.qna.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum QuestionStatus {
-    WAITING,COMPLETED
+    WAITING("대기중"),
+    COMPLETED("답변완료");
+
+    private final String korean;
+
+    QuestionStatus(String korean) {
+        this.korean = korean;
+    }
 }

--- a/src/main/java/goodspace/backend/qna/domain/QuestionType.java
+++ b/src/main/java/goodspace/backend/qna/domain/QuestionType.java
@@ -1,5 +1,16 @@
 package goodspace.backend.qna.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum QuestionType {
-    DELIVERY, ORDER, ITEM
+    DELIVERY("배송"),
+    ORDER("주문"),
+    ITEM("상품");
+
+    private final String korean;
+
+    QuestionType(String korean) {
+        this.korean = korean;
+    }
 }

--- a/src/main/java/goodspace/backend/user/domain/OAuthType.java
+++ b/src/main/java/goodspace/backend/user/domain/OAuthType.java
@@ -1,5 +1,19 @@
 package goodspace.backend.user.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum OAuthType {
-    GOOD_SPACE, APPLE, FACEBOOK, GOOGLE, KAKAO, NAVER
+    GOOD_SPACE("굿스페이스"),
+    APPLE("애플"),
+    FACEBOOK("페이스북"),
+    GOOGLE("구글"),
+    KAKAO("카카오"),
+    NAVER("네이버");
+
+    private final String korean;
+
+    OAuthType(String korean) {
+        this.korean = korean;
+    }
 }


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
종류/카테고리 추가시 클라이언트 코드를 수정하는 상황을 방지하기 위해, 종류/카테고리의 데이터와 한글 번역명을 전달하는 API를 구현했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#128 
