### PR TITLE
[feat/#82] 만료된 EmailVerification 정기적 삭제 구현

### DIFF
--- a/src/main/java/goodspace/backend/email/domain/EmailVerificationCleaner.java
+++ b/src/main/java/goodspace/backend/email/domain/EmailVerificationCleaner.java
@@ -1,0 +1,5 @@
+package goodspace.backend.email.domain;
+
+public interface EmailVerificationCleaner {
+    void clean();
+}

--- a/src/main/java/goodspace/backend/email/domain/EmailVerificationCleanerImpl.java
+++ b/src/main/java/goodspace/backend/email/domain/EmailVerificationCleanerImpl.java
@@ -1,0 +1,30 @@
+package goodspace.backend.email.domain;
+
+import goodspace.backend.email.entity.EmailVerification;
+import goodspace.backend.email.repository.EmailVerificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class EmailVerificationCleanerImpl implements EmailVerificationCleaner {
+    private final EmailVerificationRepository emailVerificationRepository;
+
+    @Override
+    @Transactional
+    public void clean() {
+        List<EmailVerification> deletableEmailVerifications = emailVerificationRepository.findAll().stream()
+                .filter(this::isHasToBeDeleted)
+                .toList();
+
+        emailVerificationRepository.deleteAll(deletableEmailVerifications);
+    }
+
+    private boolean isHasToBeDeleted(EmailVerification emailVerification) {
+        return !emailVerification.isVerified() && emailVerification.isExpired(LocalDateTime.now());
+    }
+}

--- a/src/main/java/goodspace/backend/email/dto/CodeSendRequestDto.java
+++ b/src/main/java/goodspace/backend/email/dto/CodeSendRequestDto.java
@@ -1,5 +1,8 @@
 package goodspace.backend.email.dto;
 
+import lombok.Builder;
+
+@Builder
 public record CodeSendRequestDto(
         String email
 ) {

--- a/src/main/java/goodspace/backend/email/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/goodspace/backend/email/service/EmailVerificationServiceImpl.java
@@ -11,7 +11,6 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +24,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
     private static final int CODE_LENGTH = 6;
     private static final int EXPIRE_MINUTES = 5;
 
-    private static final Supplier<DataIntegrityViolationException> DUPLICATED_EMAIL = () -> new DataIntegrityViolationException("이미 존재하는 이메일입니다.");
+    private static final Supplier<IllegalArgumentException> DUPLICATED_EMAIL = () -> new IllegalArgumentException("이미 존재하는 이메일입니다.");
     private static final Supplier<EntityNotFoundException> EMAIL_NOT_FOUND = () -> new EntityNotFoundException("이메일을 찾을 수 없습니다.");
     private static final Supplier<IllegalArgumentException> ILLEGAL_CODE = () -> new IllegalArgumentException("코드가 올바르지 않습니다.");
     private static final Supplier<IllegalStateException> EXPIRED = () -> new IllegalStateException("이메일 인증이 만료되었습니다.");
@@ -42,7 +41,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
     public void sendVerificationCode(CodeSendRequestDto requestDto) throws MessagingException {
         String email = requestDto.email();
 
-        if (isAlreadyExistEmail(email)) {
+        if (isDuplicatedEmail(email)) {
             throw DUPLICATED_EMAIL.get();
         }
 
@@ -54,10 +53,11 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
                 .code(code)
                 .expiresAt(now.plusMinutes(EXPIRE_MINUTES))
                 .createdAt(now)
+                .isVerified(false)
                 .build();
 
+        updateOrCreate(emailVerification);
         sendEmail(email, code);
-        emailVerificationRepository.save(emailVerification);
     }
 
     @Override
@@ -80,14 +80,9 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
         emailVerification.verify();
     }
 
-    private boolean isAlreadyExistEmail(String email) {
-        boolean userExist = userRepository.findByEmail(email)
+    private boolean isDuplicatedEmail(String email) {
+        return userRepository.findByEmail(email)
                 .isPresent();
-
-        boolean emailVerificationExist = emailVerificationRepository.findByEmail(email)
-                .isPresent();
-
-        return userExist || emailVerificationExist;
     }
 
     private void sendEmail(String to, String code) throws MessagingException {
@@ -95,5 +90,20 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
         messageBuilder.fillContent(message, to, code, EXPIRE_MINUTES);
 
         mailSender.send(message);
+    }
+
+    private void updateOrCreate(EmailVerification emailVerification) {
+        String email = emailVerification.getEmail();
+
+        if (emailVerificationRepository.findByEmail(email).isEmpty()) {
+            emailVerificationRepository.save(emailVerification);
+            return;
+        }
+
+        EmailVerification existEmailVerification = emailVerificationRepository.findByEmail(email).get();
+
+        existEmailVerification.setCode(emailVerification.getCode());
+        existEmailVerification.setExpiresAt(emailVerification.getExpiresAt());
+        existEmailVerification.setVerified(emailVerification.isVerified());
     }
 }

--- a/src/main/java/goodspace/backend/email/service/EmailVerificationServiceImpl.java
+++ b/src/main/java/goodspace/backend/email/service/EmailVerificationServiceImpl.java
@@ -37,6 +37,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
     private final MessageBuilder messageBuilder;
     private final CodeGenerator codeGenerator;
 
+    @Override
     @Transactional
     public void sendVerificationCode(CodeSendRequestDto requestDto) throws MessagingException {
         String email = requestDto.email();
@@ -59,6 +60,7 @@ public class EmailVerificationServiceImpl implements EmailVerificationService {
         emailVerificationRepository.save(emailVerification);
     }
 
+    @Override
     @Transactional
     public void verifyEmail(VerifyRequestDto requestDto) {
         String email = requestDto.email();

--- a/src/main/java/goodspace/backend/email/sheduler/EmailVerificationCleanupScheduler.java
+++ b/src/main/java/goodspace/backend/email/sheduler/EmailVerificationCleanupScheduler.java
@@ -1,0 +1,19 @@
+package goodspace.backend.email.sheduler;
+
+import goodspace.backend.email.domain.EmailVerificationCleaner;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class EmailVerificationCleanupScheduler {
+    private final EmailVerificationCleaner emailVerificationCleaner;
+
+    @Scheduled(cron = "0 0 * * * *")
+    @Transactional
+    public void regularlyCleanEmailVerifications() {
+        emailVerificationCleaner.clean();
+    }
+}

--- a/src/test/java/goodspace/backend/email/domain/EmailVerificationCleanerTest.java
+++ b/src/test/java/goodspace/backend/email/domain/EmailVerificationCleanerTest.java
@@ -1,0 +1,67 @@
+package goodspace.backend.email.domain;
+
+import goodspace.backend.email.entity.EmailVerification;
+import goodspace.backend.email.repository.EmailVerificationRepository;
+import goodspace.backend.fixture.EmailVerificationFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class EmailVerificationCleanerTest {
+    @Autowired
+    EmailVerificationCleaner emailVerificationCleaner;
+    @Autowired
+    EmailVerificationRepository emailVerificationRepository;
+
+    EmailVerification expiredEmailVerification;
+    EmailVerification notExpriedEmailVerification;
+    EmailVerification expiredAndVerifedEmailVerification;
+
+    @BeforeEach
+    void resetEntities() {
+        expiredEmailVerification = emailVerificationRepository.save(EmailVerificationFixture.EXPIRED.getInstance());
+        notExpriedEmailVerification = emailVerificationRepository.save(EmailVerificationFixture.NOT_EXPIRED.getInstance());
+        expiredAndVerifedEmailVerification = emailVerificationRepository.save(EmailVerificationFixture.EXPIRED_AND_VERIFIED.getInstance());
+    }
+
+    @Nested
+    class clean {
+        @Test
+        @DisplayName("만료된 이메일 인증 정보를 제거한다")
+        void removeExpiredEmailVerification() {
+            emailVerificationCleaner.clean();
+
+            boolean expiredIsDeleted = emailVerificationRepository.findById(expiredEmailVerification.getId())
+                    .isEmpty();
+            assertThat(expiredIsDeleted).isTrue();
+        }
+
+        @Test
+        @DisplayName("만료됐더라도 인증된 이메일이라면 제거하지 않는다")
+        void notRemoveIfVerifiedEmailVerification() {
+            emailVerificationCleaner.clean();
+
+            boolean verifiedIsDeleted = emailVerificationRepository.findById(expiredAndVerifedEmailVerification.getId())
+                    .isEmpty();
+            assertThat(verifiedIsDeleted).isFalse();
+        }
+
+        @Test
+        @DisplayName("만료되지 않은 이메일 인증 정보는 제거하지 않는다")
+        void notRemoveIfNotExpiredEmailVerification() {
+            emailVerificationCleaner.clean();
+
+            boolean notExpiredIsDeleted = emailVerificationRepository.findById(notExpriedEmailVerification.getId())
+                    .isEmpty();
+            assertThat(notExpiredIsDeleted).isFalse();
+        }
+    }
+}

--- a/src/test/java/goodspace/backend/email/service/EmailVerificationServiceTest.java
+++ b/src/test/java/goodspace/backend/email/service/EmailVerificationServiceTest.java
@@ -6,8 +6,11 @@ import goodspace.backend.email.entity.EmailVerification;
 import goodspace.backend.email.repository.EmailVerificationRepository;
 import goodspace.backend.fixture.EmailFixture;
 import goodspace.backend.fixture.EmailVerificationFixture;
+import goodspace.backend.fixture.GoodSpaceUserFixture;
+import goodspace.backend.user.domain.GoodSpaceUser;
+import goodspace.backend.user.repository.UserRepository;
 import jakarta.mail.MessagingException;
-import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,17 +18,34 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional
-@RequiredArgsConstructor(onConstructor_ = @Autowired)
 class EmailVerificationServiceTest {
-    private static final String NOISE = "2193812";
+    static final String NOISE = "2193812555555123";
 
-    private final EmailVerificationService emailVerificationService;
-    private final EmailVerificationRepository emailVerificationRepository;
+    @Autowired
+    EmailVerificationService emailVerificationService;
+    @Autowired
+    EmailVerificationRepository emailVerificationRepository;
+    @Autowired
+    UserRepository userRepository;
+
+    String existEmail;
+    EmailVerification existEmailVerification;
+
+    @BeforeEach
+    void resetEntities() {
+        GoodSpaceUser user = userRepository.save(GoodSpaceUserFixture.DEFAULT.getInstance());
+        existEmail = user.getEmail();
+
+        existEmailVerification = emailVerificationRepository.save(EmailVerificationFixture.NOT_VERIFIED.getInstance());
+        existEmailVerification.setCode(NOISE);
+    }
 
     @Nested
     class sendVerificationCode {
@@ -43,6 +63,40 @@ class EmailVerificationServiceTest {
                     .isPresent();
             assertThat(isPresent).isTrue();
         }
+
+        @Test
+        @DisplayName("이미 회원가입된 이메일이라면 예외를 던진다")
+        void ifUsedEmailThenThrowException() {
+            CodeSendRequestDto requestDto = CodeSendRequestDto.builder()
+                    .email(existEmail)
+                    .build();
+
+            assertThatThrownBy(() -> emailVerificationService.sendVerificationCode(requestDto))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("기존에 같은 이메일의 EmailVerification이 존재한다면 덮어써 갱신한다")
+        void idExistEmailVerificationThenUpdate() throws MessagingException {
+            // given
+            String existEmail = existEmailVerification.getEmail();
+            LocalDateTime existExpiredTime = existEmailVerification.getExpiresAt();
+            String existCode = existEmailVerification.getCode();
+
+            CodeSendRequestDto requestDto = CodeSendRequestDto.builder()
+                    .email(existEmail)
+                    .build();
+
+            // when
+            emailVerificationService.sendVerificationCode(requestDto);
+
+            // then
+            LocalDateTime updatedExpiredTime = existEmailVerification.getExpiresAt();
+            String updatedCode = existEmailVerification.getCode();
+
+            assertThat(updatedExpiredTime).isNotEqualTo(existExpiredTime);
+            assertThat(updatedCode).isNotEqualTo(existCode);
+        }
     }
 
     @Nested
@@ -51,13 +105,10 @@ class EmailVerificationServiceTest {
         @DisplayName("코드가 일치하면 이메일을 인증 처리 한다")
         void ifCodeSameThenVerifyEmail() {
             // given
-            EmailVerification emailVerification = EmailVerificationFixture.NOT_VERIFIED.getInstance();
-            emailVerificationRepository.save(emailVerification);
+            String email = existEmailVerification.getEmail();
+            String correctCode = existEmailVerification.getCode();
 
             // when
-            String email = emailVerification.getEmail();
-            String correctCode = emailVerification.getCode();
-
             emailVerificationService.verifyEmail(new VerifyRequestDto(email, correctCode));
 
             // then
@@ -70,12 +121,8 @@ class EmailVerificationServiceTest {
         @DisplayName("코드가 일치하지 않으면 예외를 발생시킨다")
         void ifCodeDifferentThenThrowException() {
             // given
-            EmailVerification emailVerification = EmailVerificationFixture.NOT_VERIFIED.getInstance();
-            emailVerificationRepository.save(emailVerification);
-
-            // when
-            String email = emailVerification.getEmail();
-            String wrongCode = emailVerification.getCode() + NOISE;
+            String email = existEmailVerification.getEmail();
+            String wrongCode = existEmailVerification.getCode() + NOISE;
 
             // then
             assertThatThrownBy(() -> emailVerificationService.verifyEmail(new VerifyRequestDto(email, wrongCode)))

--- a/src/test/java/goodspace/backend/fixture/EmailVerificationFixture.java
+++ b/src/test/java/goodspace/backend/fixture/EmailVerificationFixture.java
@@ -25,9 +25,15 @@ public enum EmailVerificationFixture {
     ),
     EXPIRED(
             "expired@email.com",
-            "789789",
+            "987654",
             LocalDateTime.now().minusMinutes(1),
             false
+    ),
+    EXPIRED_AND_VERIFIED(
+            "expired_and_verified@email.com",
+            "668866",
+            LocalDateTime.now().minusMinutes(1),
+            true
     );
 
     private final String email;


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
만료된 이메일 인증 정보가 주기적으로 삭제되도록 구현했습니다.
같은 이메일로 여러 번 인증 요청을 보내면, 기존의 객체를 덮어쓰게 수정했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#82 
