### PR TITLE
[feat/#146] error handling in nicepayController and delete orderOutId…

### DIFF
--- a/src/main/java/goodspace/backend/order/controller/NicePayController.java
+++ b/src/main/java/goodspace/backend/order/controller/NicePayController.java
@@ -7,6 +7,7 @@ import goodspace.backend.order.domain.PaymentApproveResult;
 import goodspace.backend.order.dto.PaymentVerifyRequestDto;
 import goodspace.backend.order.service.NicePayService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -22,6 +23,7 @@ import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
+@Slf4j
 public class NicePayController {
     private final NicePayService nicePayService;
 
@@ -36,7 +38,7 @@ public class NicePayController {
     }
 
     @RequestMapping("/payment/verify")
-    public String verifyPayment(@ModelAttribute PaymentVerifyRequestDto paymentVerifyResultDto, Model model) throws JsonProcessingException {
+    public ResponseEntity<Map<String, String>> verifyPayment(@ModelAttribute PaymentVerifyRequestDto paymentVerifyResultDto, Model model) throws JsonProcessingException {
 
         model.addAttribute("paymentVerifyResultDto", paymentVerifyResultDto);
 
@@ -73,25 +75,49 @@ public class NicePayController {
 
             System.out.println(responseNode.toPrettyString());
 
-            if (resultCode.equalsIgnoreCase("0000")){
-                //TODO
-                //해당 결제 응답을 유저와 매핑하여 저장할 서비스 - 레포지토리 로직 필요
-                // tid와 amout저장 후에 추후 환불로직에도 쓰여야 함.
-                PaymentApproveResult result = mapper.treeToValue(responseNode, PaymentApproveResult.class);
-                nicePayService.MappingOrderWithPaymentApproveResult(result);
+            if (resultCode.equalsIgnoreCase("0000")) {
+                int tryCount = 5;
 
+                while (tryCount > 0) {
+                    try {
+                        PaymentApproveResult result = mapper.treeToValue(responseNode, PaymentApproveResult.class);
+                        nicePayService.MappingOrderWithPaymentApproveResult(result);
+                        break;
+                    } catch (IllegalArgumentException e) {
+                        return ResponseEntity
+                                .status(HttpStatus.BAD_REQUEST)
+                                .body(Map.of("error", "IllegalArgumentException에러가 발생하였습니다.PaymentApproveResult와 order매핑에 실패하였습니다." + e.getMessage()));
+                    } catch (Exception e) {
+                        log.info("[info 에러 발생]", e.getMessage());
+                        tryCount--;
+                    }
+                }
+
+                if (tryCount == 0){
+                    return ResponseEntity
+                            .status(HttpStatus.BAD_REQUEST)
+                            .body(Map.of("error", "IllegalArgumentException를 제외한 에러가 발생하였습니다. 상위 에러메세지를 확인하세요."));
+                }
             }
-            else{
 
+            else {
+                return ResponseEntity
+                        .status(HttpStatus.BAD_REQUEST)
+                        .body(Map.of("error", "Payment의 ResultCode가 0000이 아닙니다. 결제에 실패하였습니다."));
             }
 
         } catch (HttpClientErrorException e) {
-            System.out.println("클라이언트 에러: " + e.getStatusCode() + " - " + e.getResponseBodyAsString());
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("error", "클라이언트 에러 발생." + e.getMessage()));
         } catch (HttpServerErrorException e) {
-            System.out.println("서버 에러: " + e.getStatusCode() + " - " + e.getResponseBodyAsString());
+            return ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of("error", "서버에 에러 발생." + e.getMessage()));
         }
 
-        return "paymentVerifyResult";
+        return ResponseEntity
+                .ok(Map.of("message", "결제에 성공했습니다."));
     }
 
     @RequestMapping(value="/cancel")

--- a/src/main/java/goodspace/backend/order/controller/OrderController.java
+++ b/src/main/java/goodspace/backend/order/controller/OrderController.java
@@ -15,11 +15,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
     private final OrderService orderService;
 
-    //TODO - order에 delivery 임베더블 해놨으니, 로직 수정하시오.
     @PostMapping
-    public ResponseEntity<String> createOrder(@RequestBody OrderRequestDto orderRequest) {
-        orderService.saveOrder(orderRequest);
-        return ResponseEntity.ok("Order created");
+    public ResponseEntity<Long> createOrder(@RequestBody OrderRequestDto orderRequest) {
+        return ResponseEntity.ok(orderService.saveOrder(orderRequest));
     }
 }
 

--- a/src/main/java/goodspace/backend/order/domain/Order.java
+++ b/src/main/java/goodspace/backend/order/domain/Order.java
@@ -29,8 +29,6 @@ public class Order extends BaseEntity {
     @Embedded
     private Delivery delivery;
 
-    private String orderOutId;
-
     @Enumerated(EnumType.STRING)
     @Builder.Default
     private OrderStatus orderStatus = OrderStatus.PAYMENT_CONFIRMED;

--- a/src/main/java/goodspace/backend/order/dto/OrderRequestDto.java
+++ b/src/main/java/goodspace/backend/order/dto/OrderRequestDto.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Getter
 public class OrderRequestDto extends BaseEntity {
-    private String orderOutId;
+    private String orderId;
     private long userId;
     private List<OrderCartItemDto> orderCartItemDtos;
 }

--- a/src/main/java/goodspace/backend/order/service/NicePayService.java
+++ b/src/main/java/goodspace/backend/order/service/NicePayService.java
@@ -4,18 +4,27 @@ import goodspace.backend.order.domain.Order;
 import goodspace.backend.order.domain.PaymentApproveResult;
 import goodspace.backend.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class NicePayService {
     private final OrderRepository orderRepository;
 
     public void MappingOrderWithPaymentApproveResult(PaymentApproveResult approveResult) {
-        System.out.println("OrderID는 : " + approveResult.getOrderId());
-        Order order = orderRepository.findByOrderOutId(approveResult.getOrderId())
-                .orElseThrow(() -> new IllegalArgumentException("결제 성공 후, 결제API에서 응답받은 orderId로 orderRepository에 해당 order를 찾을 수 없습니다."));
+        try {
+            Order order = orderRepository.findByOrderOutId(approveResult.getOrderId())
+                    .orElseThrow(() -> new IllegalArgumentException("결제 성공 후, 결제API에서 응답받은 orderId로 orderRepository에 해당 order를 찾을 수 없습니다."));
 
-        order.setPaymentApproveResult(approveResult);
+            order.setPaymentApproveResult(approveResult);
+
+        } catch (IllegalArgumentException e) {
+            log.error("[error 단계 에러]에러 발생", e);
+
+        } catch (Exception e) {
+            log.info("[info 단계 에러] 예기치 못한 오류: ", e.getMessage());
+        }
     }
 }

--- a/src/main/java/goodspace/backend/order/service/OrderService.java
+++ b/src/main/java/goodspace/backend/order/service/OrderService.java
@@ -11,6 +11,7 @@ import goodspace.backend.global.repository.ItemRepository;
 import goodspace.backend.order.repository.OrderRepository;
 import goodspace.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -23,13 +24,14 @@ public class OrderService {
     private final OrderRepository orderRepository;
     private final ItemRepository itemRepository;
 
-    public void saveOrder(OrderRequestDto orderRequest) {
+    //TODO - error handling
+    public Long saveOrder(OrderRequestDto orderRequest) {
         User user = userRepository.findById(orderRequest.getUserId())
                 .orElseThrow(() -> new IllegalArgumentException("Order엔티티에 User를 매핑하는 Service과정에서 User를 찾는 것을 실패했습니다."));
 
         Order order = Order.builder()
                 .user(user)
-                .orderOutId(orderRequest.getOrderOutId())
+                .delivery(user.getDelivery())
                 .build();
 
         List<OrderCartItem> orderCartItems = orderRequest.getOrderCartItemDtos().stream()
@@ -45,8 +47,11 @@ public class OrderService {
                 .collect(Collectors.toList());
 
         order.setOrderCartItems(orderCartItems);
-
         orderRepository.save(order);
+
+
+
+        return order.getId();
     }
 
     public OrderResponseDto findOrderByOrderId(String orderId) {


### PR DESCRIPTION
… logic in order entity, saveOrder serivce

## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
1. 결제 요청 (verifyPayment)에서의 에러 핸들링 로직을 추가하였습니다.
2. 오더 저장(saveOrder)와 결제 요청(verifyPayment)에 쓰이는 OrderOutId를 삭제하고 OrderId를 사용하는 로직으로 변경하였습니다.
## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->

## 📝 참고할 사항
order와 paymentResult를 연결하는 과정에서 서버 및 통신 에러가 발생할 경우, 사용자에게는 정상적으로 결제완료 창을 띄우기로 했으나,
현재 로직은 각각의 에러에 맞는 에러메시지를 Return합니다.

사용자에게 결제완료 창을 띄우고, 서버 측에서 후조치를 하기 위해서는 서버 및 통신 에러라는 명확한 이유로 에러가 발생해야하나 클라이언트 측에서의 에러를 무시할 수 없어 에러메시지를 return하는 것으로 로직을 작성하였습니다.
리팩토링할 때, 에러 단계를 구체화하여 후조치를 할 수 있게끔 로직을 작성해야할 듯 합니다.

## 🎯 코드 리뷰 시 중점적으로 보면 좋은 내용
