### PR TITLE
[chore] 이메일 인증 API의 이메일 중복 여부를 유연하게 개선

### DIFF
--- a/src/main/java/goodspace/backend/email/dto/CodeSendRequestDto.java
+++ b/src/main/java/goodspace/backend/email/dto/CodeSendRequestDto.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record CodeSendRequestDto(
-        String email
+        String email,
+        boolean shouldAlreadyExist
 ) {
 }


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
이메일 인증 API가 동작할 때, 이미 존재해야 하는 이메일인지 아닌지를 파라미터를 통해 판단하도록 개선했습니다.