### PR TITLE
[feat/#143] 관리자용 주문 관리 API 구현

### DIFF
--- a/src/main/java/goodspace/backend/admin/controller/AdminQuestionController.java
+++ b/src/main/java/goodspace/backend/admin/controller/AdminQuestionController.java
@@ -17,7 +17,7 @@ import java.util.List;
 @RequestMapping("/admin/question")
 @RequiredArgsConstructor
 @Tag(
-        name = "관리자 전용 QNA게시판",
+        name = "QNA게시판(관리자 전용)",
         description = "답변 등록 및 질문 상태 변경"
 )
 public class AdminQuestionController {

--- a/src/main/java/goodspace/backend/admin/controller/ClientManageController.java
+++ b/src/main/java/goodspace/backend/admin/controller/ClientManageController.java
@@ -20,8 +20,8 @@ import java.util.List;
 @RequestMapping("/admin/client")
 @RequiredArgsConstructor
 @Tag(
-        name = "클라이언트 관리 API",
-        description = "클라이언트 관리 관련 기능(관리자 전용)"
+        name = "클라이언트 관리 API(관리자 전용)",
+        description = "클라이언트 관리 관련 기능"
 )
 public class ClientManageController {
     private final ClientManageService clientManageService;

--- a/src/main/java/goodspace/backend/admin/controller/ItemImageManageController.java
+++ b/src/main/java/goodspace/backend/admin/controller/ItemImageManageController.java
@@ -17,8 +17,8 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/admin/item/image")
 @RequiredArgsConstructor
 @Tag(
-        name = "상품 이미지 관리 API",
-        description = "상품 이미지 관리 관련 기능(관리자 전용)"
+        name = "상품 이미지 관리 API(관리자 전용)",
+        description = "상품 이미지 관리 관련 기능"
 )
 public class ItemImageManageController {
     private final ItemImageManageService itemImageManageService;

--- a/src/main/java/goodspace/backend/admin/controller/ItemManageController.java
+++ b/src/main/java/goodspace/backend/admin/controller/ItemManageController.java
@@ -17,8 +17,8 @@ import java.util.List;
 @RequestMapping("/admin/item")
 @RequiredArgsConstructor
 @Tag(
-        name = "상품 관리 API",
-        description = "상품 관리 관련 기능(관리자 전용)"
+        name = "상품 관리 API(관리자 전용)",
+        description = "상품 관리 관련 기능"
 )
 public class ItemManageController {
     private final ItemManageService itemManageService;

--- a/src/main/java/goodspace/backend/admin/controller/OrderManageController.java
+++ b/src/main/java/goodspace/backend/admin/controller/OrderManageController.java
@@ -1,0 +1,56 @@
+package goodspace.backend.admin.controller;
+
+import goodspace.backend.admin.dto.order.OrderInfoResponseDto;
+import goodspace.backend.admin.dto.order.OrderUpdateRequestDto;
+import goodspace.backend.admin.service.order.OrderManageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/admin/order")
+@RequiredArgsConstructor
+@Tag(
+        name = "주문 관리 API(관리자 전용)",
+        description = "주문 조회/수정/삭제 관련 기능"
+)
+public class OrderManageController {
+    private final OrderManageService orderManageService;
+
+    @GetMapping
+    @Operation(
+            summary = "주문 조회",
+            description = "모든 주문 정보를 조회합니다."
+    )
+    public ResponseEntity<List<OrderInfoResponseDto>> getOrders() {
+        List<OrderInfoResponseDto> response = orderManageService.getOrders();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping
+    @Operation(
+            summary = "주문 정보 수정",
+            description = "주문의 배송지 정보와 승인 정보를 수정합니다."
+    )
+    public ResponseEntity<Void> updateOrderInfo(@RequestBody OrderUpdateRequestDto requestDto) {
+        orderManageService.updateOrder(requestDto);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping
+    @Operation(
+            summary = "주문 삭제",
+            description = "주문을 삭제합니다."
+    )
+    public ResponseEntity<Void> deleteOrder(@RequestParam Long orderId) {
+        orderManageService.removeOrder(orderId);
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/goodspace/backend/admin/controller/UserManageController.java
+++ b/src/main/java/goodspace/backend/admin/controller/UserManageController.java
@@ -14,7 +14,7 @@ import java.util.List;
 @RequestMapping("/admin/user")
 @RequiredArgsConstructor
 @Tag(
-        name = "회원 API(관리자용)",
+        name = "회원 API(관리자 전용)",
         description = "회원 정보 조회/수정 관련 기능"
 )
 public class UserManageController {

--- a/src/main/java/goodspace/backend/admin/dto/order/OrderInfoResponseDto.java
+++ b/src/main/java/goodspace/backend/admin/dto/order/OrderInfoResponseDto.java
@@ -1,0 +1,40 @@
+package goodspace.backend.admin.dto.order;
+
+import goodspace.backend.admin.dto.item.ItemInfoResponseDto;
+import goodspace.backend.order.domain.Order;
+import goodspace.backend.order.domain.OrderCartItem;
+import goodspace.backend.order.domain.OrderStatus;
+import goodspace.backend.order.domain.PaymentApproveResult;
+import goodspace.backend.user.domain.Delivery;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record OrderInfoResponseDto(
+        Long id,
+        PaymentApproveResult approveResult,
+        Delivery deliveryInfo,
+        OrderStatus status,
+        LocalDateTime createAt,
+        LocalDateTime updatedAt,
+        List<ItemInfoResponseDto> items
+) {
+    public static OrderInfoResponseDto from(Order order) {
+        List<ItemInfoResponseDto> items = order.getOrderCartItems().stream()
+                .map(OrderCartItem::getItem)
+                .map(ItemInfoResponseDto::from)
+                .toList();
+
+        return OrderInfoResponseDto.builder()
+                .id(order.getId())
+                .approveResult(order.getApproveResult())
+                .deliveryInfo(order.getDelivery())
+                .status(order.getOrderStatus())
+                .createAt(order.getCreatedAt())
+                .updatedAt(order.getUpdatedAt())
+                .items(items)
+                .build();
+    }
+}

--- a/src/main/java/goodspace/backend/admin/dto/order/OrderStatusChangeRequestDto.java
+++ b/src/main/java/goodspace/backend/admin/dto/order/OrderStatusChangeRequestDto.java
@@ -1,0 +1,9 @@
+package goodspace.backend.admin.dto.order;
+
+import goodspace.backend.order.domain.OrderStatus;
+
+public record OrderStatusChangeRequestDto(
+        Long orderId,
+        OrderStatus status
+) {
+}

--- a/src/main/java/goodspace/backend/admin/dto/order/OrderUpdateRequestDto.java
+++ b/src/main/java/goodspace/backend/admin/dto/order/OrderUpdateRequestDto.java
@@ -1,0 +1,13 @@
+package goodspace.backend.admin.dto.order;
+
+import goodspace.backend.order.domain.PaymentApproveResult;
+import goodspace.backend.user.domain.Delivery;
+import lombok.Builder;
+
+@Builder
+public record OrderUpdateRequestDto(
+    Long orderId,
+    PaymentApproveResult approveResult,
+    Delivery deliveryInfo
+) {
+}

--- a/src/main/java/goodspace/backend/admin/dto/order/TrackingNumberRegisterRequestDto.java
+++ b/src/main/java/goodspace/backend/admin/dto/order/TrackingNumberRegisterRequestDto.java
@@ -1,0 +1,10 @@
+package goodspace.backend.admin.dto.order;
+
+import lombok.Builder;
+
+@Builder
+public record TrackingNumberRegisterRequestDto(
+        Long orderId,
+        String trackingNumber
+) {
+}

--- a/src/main/java/goodspace/backend/admin/service/order/OrderManageService.java
+++ b/src/main/java/goodspace/backend/admin/service/order/OrderManageService.java
@@ -1,0 +1,19 @@
+package goodspace.backend.admin.service.order;
+
+import goodspace.backend.admin.dto.order.OrderInfoResponseDto;
+import goodspace.backend.admin.dto.order.OrderUpdateRequestDto;
+import goodspace.backend.admin.dto.order.TrackingNumberRegisterRequestDto;
+
+import java.util.List;
+
+public interface OrderManageService {
+    List<OrderInfoResponseDto> getOrders();
+
+    void acceptOrder(long orderId);
+
+    void registerTrackingNumber(TrackingNumberRegisterRequestDto requestDto);
+
+    void updateOrder(OrderUpdateRequestDto requestDto);
+
+    void removeOrder(long orderId);
+}

--- a/src/main/java/goodspace/backend/admin/service/order/OrderManageServiceImpl.java
+++ b/src/main/java/goodspace/backend/admin/service/order/OrderManageServiceImpl.java
@@ -1,0 +1,75 @@
+package goodspace.backend.admin.service.order;
+
+import goodspace.backend.admin.dto.order.OrderInfoResponseDto;
+import goodspace.backend.admin.dto.order.OrderUpdateRequestDto;
+import goodspace.backend.admin.dto.order.TrackingNumberRegisterRequestDto;
+import goodspace.backend.order.domain.Order;
+import goodspace.backend.order.domain.OrderStatus;
+import goodspace.backend.order.repository.OrderRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+@Service
+@RequiredArgsConstructor
+public class OrderManageServiceImpl implements OrderManageService {
+    private static final Supplier<EntityNotFoundException> ORDER_NOT_FOUND = () -> new EntityNotFoundException("주문을 찾을 수 없습니다.");
+    private static final Supplier<IllegalStateException> ILLEGAL_ORDER_STATE = () -> new IllegalStateException("요청을 처리하기에 주문의 상태가 부적절합니다.");
+
+    private final OrderRepository orderRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<OrderInfoResponseDto> getOrders() {
+        return orderRepository.findAll().stream()
+                .map(OrderInfoResponseDto::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public void acceptOrder(long orderId) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(ORDER_NOT_FOUND);
+
+        if (order.getOrderStatus() != OrderStatus.PREPARING_PRODUCT) {
+            throw ILLEGAL_ORDER_STATE.get();
+        }
+
+        order.updateOrderStatus(OrderStatus.MAKING_PRODUCT);
+    }
+
+    @Override
+    @Transactional
+    public void registerTrackingNumber(TrackingNumberRegisterRequestDto requestDto) {
+        Order order = orderRepository.findById(requestDto.orderId())
+                .orElseThrow(ORDER_NOT_FOUND);
+
+        if (order.getOrderStatus() != OrderStatus.MAKING_PRODUCT) {
+            throw ILLEGAL_ORDER_STATE.get();
+        }
+
+        order.setTrackingNumber(requestDto.trackingNumber());
+        order.updateOrderStatus(OrderStatus.PREPARING_DELIVERY);
+    }
+
+    @Override
+    @Transactional
+    public void updateOrder(OrderUpdateRequestDto requestDto) {
+        Order order = orderRepository.findById(requestDto.orderId())
+                .orElseThrow(ORDER_NOT_FOUND);
+
+        order.setPaymentApproveResult(requestDto.approveResult());
+        order.setDelivery(requestDto.deliveryInfo());
+    }
+
+    @Override
+    @Transactional
+    public void removeOrder(long orderId) {
+        orderRepository.deleteById(orderId);
+    }
+}

--- a/src/main/java/goodspace/backend/order/domain/Order.java
+++ b/src/main/java/goodspace/backend/order/domain/Order.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
@@ -27,14 +28,19 @@ public class Order extends BaseEntity {
     private PaymentApproveResult approveResult;
 
     @Embedded
+    @Setter
     private Delivery delivery;
 
     @Enumerated(EnumType.STRING)
     @Builder.Default
     private OrderStatus orderStatus = OrderStatus.PAYMENT_CHECKING;
 
+    @Setter
+    private String trackingNumber;
+
     @ManyToOne
     @JoinColumn(name = "user_id", nullable = false)
+    @Setter
     private User user;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -70,6 +76,10 @@ public class Order extends BaseEntity {
         else if (status.equals("취소")){
             this.orderStatus = OrderStatus.CANCELED;
         }
+    }
+
+    public void updateOrderStatus(OrderStatus orderStatus) {
+        this.orderStatus = orderStatus;
     }
 
     public void setPaymentApproveResult(PaymentApproveResult approveResult) {

--- a/src/main/java/goodspace/backend/order/domain/PaymentApproveResult.java
+++ b/src/main/java/goodspace/backend/order/domain/PaymentApproveResult.java
@@ -2,12 +2,17 @@ package goodspace.backend.order.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
-import lombok.Data;
+import lombok.*;
 
 import java.util.List;
+import java.util.Objects;
 
 @Data
 @Embeddable
+@EqualsAndHashCode
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class PaymentApproveResult {
     private String resultCode;
     private String resultMsg;
@@ -58,6 +63,10 @@ public class PaymentApproveResult {
 
     @Data
     @Embeddable
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @EqualsAndHashCode
     public static class CancelInfo {
         private String cancelDate;
         private String cancelAmount;
@@ -68,6 +77,10 @@ public class PaymentApproveResult {
 
     @Data
     @Embeddable
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @EqualsAndHashCode
     public static class CashReceiptInfo {
         private String receiptId;
         private String orgTid;
@@ -82,12 +95,20 @@ public class PaymentApproveResult {
 
     @Data
     @Embeddable
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @EqualsAndHashCode
     public static class Coupon {
         private int couponAmt;
     }
 
     @Data
     @Embeddable
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @EqualsAndHashCode
     public static class CardInfo {
         private String cardCode;
         private String cardName;
@@ -103,6 +124,10 @@ public class PaymentApproveResult {
 
     @Data
     @Embeddable
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @EqualsAndHashCode
     public static class VbankInfo {
         private String vbankName;
         private String vbankNumber;
@@ -113,6 +138,10 @@ public class PaymentApproveResult {
 
     @Data
     @Embeddable
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @EqualsAndHashCode
     public static class Bank {
         private String bankCode;
         private String bankName;

--- a/src/main/java/goodspace/backend/user/domain/Delivery.java
+++ b/src/main/java/goodspace/backend/user/domain/Delivery.java
@@ -3,21 +3,19 @@ package goodspace.backend.user.domain;
 
 import goodspace.backend.user.dto.UserMyPageDto;
 import jakarta.persistence.Embeddable;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Embeddable
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EqualsAndHashCode
 public class Delivery {
     private String recipient;
     private String contactNumber1;
     private String contactNumber2;
-    private Integer postalCode;
+    private String postalCode;
     private String address;
     private String detailedAddress;
 
@@ -34,6 +32,3 @@ public class Delivery {
         return delivery;
     }
 }
-
-
-

--- a/src/main/java/goodspace/backend/user/domain/User.java
+++ b/src/main/java/goodspace/backend/user/domain/User.java
@@ -115,4 +115,23 @@ public abstract class User extends BaseEntity {
         cartItems.remove(cartItem);
         cartItem.setUser(null);
     }
+
+    /**
+     * User - Order 연관관계 편의 메서드
+     */
+    public void addOrder(Order order) {
+        orders.add(order);
+        order.setUser(this);
+    }
+
+    public void addOrders(Order... orders) {
+        for (Order order : orders) {
+            addOrder(order);
+        }
+    }
+
+    public void removeOrder(Order order) {
+        orders.remove(order);
+        order.setUser(null);
+    }
 }

--- a/src/main/java/goodspace/backend/user/dto/UserMyPageDto.java
+++ b/src/main/java/goodspace/backend/user/dto/UserMyPageDto.java
@@ -12,7 +12,7 @@ public class UserMyPageDto {
     private String recipient;
     private String contactNumber1;
     private String contactNumber2;
-    private Integer postalCode;
+    private String postalCode;
     private String address;
     private String detailedAddress;
 }

--- a/src/main/java/goodspace/backend/user/dto/UserMyPageResponseDto.java
+++ b/src/main/java/goodspace/backend/user/dto/UserMyPageResponseDto.java
@@ -13,7 +13,7 @@ public class UserMyPageResponseDto {
     private String recipient;
     private String contactNumber1;
     private String contactNumber2;
-    private Integer postalCode;
+    private String postalCode;
     private String address;
     private String detailedAddress;
 }

--- a/src/test/java/goodspace/backend/admin/service/order/OrderManageServiceTest.java
+++ b/src/test/java/goodspace/backend/admin/service/order/OrderManageServiceTest.java
@@ -1,0 +1,214 @@
+package goodspace.backend.admin.service.order;
+
+import goodspace.backend.admin.dto.order.OrderInfoResponseDto;
+import goodspace.backend.admin.dto.order.OrderUpdateRequestDto;
+import goodspace.backend.admin.dto.order.TrackingNumberRegisterRequestDto;
+import goodspace.backend.fixture.DeliveryFixture;
+import goodspace.backend.fixture.GoodSpaceUserFixture;
+import goodspace.backend.fixture.PaymentApproveResultFixture;
+import goodspace.backend.order.domain.Order;
+import goodspace.backend.order.domain.PaymentApproveResult;
+import goodspace.backend.order.repository.OrderRepository;
+import goodspace.backend.user.domain.Delivery;
+import goodspace.backend.user.domain.User;
+import goodspace.backend.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import static goodspace.backend.order.domain.OrderStatus.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+class OrderManageServiceTest {
+    static final Supplier<EntityNotFoundException> DTO_NOT_FOUND = () -> new EntityNotFoundException("DTO를 찾을 수 없습니다.");
+    static final Delivery DEFAULT_DELIVERY = DeliveryFixture.A.getInstance();
+    static final Delivery NEW_DELIVERY = DeliveryFixture.B.getInstance();
+    static final PaymentApproveResultFixture DEFAULT_PAYMENT_APPROVE_RESULT_FIXTURE = PaymentApproveResultFixture.A;
+    static final PaymentApproveResultFixture NEW_PAYMENT_APPROVE_RESULT_FIXTURE = PaymentApproveResultFixture.B;
+    static final String TRACKING_NUMBER = "12345";
+
+    @Autowired
+    OrderManageService orderManageService;
+    @Autowired
+    OrderRepository orderRepository;
+    @Autowired
+    UserRepository userRepository;
+
+    Order order;
+    Order preparingProductOrder;
+    Order makingProductOrder;
+
+    List<Order> existOrders;
+
+    @BeforeEach
+    void resetEntities() {
+        User user = userRepository.save(GoodSpaceUserFixture.DEFAULT.getInstance());
+
+        order = orderRepository.save(Order.builder()
+                .delivery(DEFAULT_DELIVERY)
+                .user(user)
+                .build());
+        order.setPaymentApproveResult(DEFAULT_PAYMENT_APPROVE_RESULT_FIXTURE.getInstanceWith(order.getId()));
+
+        preparingProductOrder = orderRepository.save(Order.builder()
+                .delivery(DEFAULT_DELIVERY)
+                .orderStatus(PREPARING_PRODUCT)
+                .user(user)
+                .build());
+        preparingProductOrder.setPaymentApproveResult(DEFAULT_PAYMENT_APPROVE_RESULT_FIXTURE.getInstanceWith(preparingProductOrder.getId()));
+
+        makingProductOrder = orderRepository.save(Order.builder()
+                .delivery(DEFAULT_DELIVERY)
+                .orderStatus(MAKING_PRODUCT)
+                .user(user)
+                .build());
+        makingProductOrder.setPaymentApproveResult(DEFAULT_PAYMENT_APPROVE_RESULT_FIXTURE.getInstanceWith(makingProductOrder.getId()));
+
+        user.addOrders(order, preparingProductOrder, makingProductOrder);
+        existOrders = List.of(order, preparingProductOrder, makingProductOrder);
+    }
+
+    @Nested
+    class getOrders {
+        @Test
+        @DisplayName("모든 주문을 조회한다")
+        void getEveryOrder() {
+            List<OrderInfoResponseDto> orderDtos = orderManageService.getOrders();
+
+            assertThat(orderDtos.size()).isEqualTo(existOrders.size());
+
+            for (Order existOrder : existOrders) {
+                OrderInfoResponseDto orderDto = findDtoById(existOrder.getId(), orderDtos);
+
+                assertThat(isEqualWithoutItem(existOrder, orderDto)).isTrue();
+            }
+        }
+    }
+
+    @Nested
+    class acceptOrder {
+        @Test
+        @DisplayName("주문의 상태를 '제작중'으로 전이한다")
+        void changeOrderStatusToMakingProduct() {
+            orderManageService.acceptOrder(preparingProductOrder.getId());
+
+            assertThat(preparingProductOrder.getOrderStatus()).isSameAs(MAKING_PRODUCT);
+        }
+
+        @Test
+        @DisplayName("주문의 상태가 '제작 준비중'이 아니라면 예외가 발생한다")
+        void ifOrderStatusIsNotPaymentCheckingThenThrowException() {
+            assertThatThrownBy(() -> orderManageService.acceptOrder(makingProductOrder.getId()))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    @Nested
+    class registerTrackingNumber {
+        @Test
+        @DisplayName("주문 엔티티에 등기 번호를 등록한다")
+        void registerTrackingNumberToOrder() {
+            // given
+            TrackingNumberRegisterRequestDto requestDto = TrackingNumberRegisterRequestDto.builder()
+                    .orderId(makingProductOrder.getId())
+                    .trackingNumber(TRACKING_NUMBER)
+                    .build();
+
+            // when
+            orderManageService.registerTrackingNumber(requestDto);
+
+            // then
+            assertThat(makingProductOrder.getTrackingNumber()).isEqualTo(TRACKING_NUMBER);
+        }
+
+        @Test
+        @DisplayName("주문의 상태를 '배송 준비중'으로 전이한다")
+        void changeOrderStatusToShipping() {
+            // given
+            TrackingNumberRegisterRequestDto requestDto = TrackingNumberRegisterRequestDto.builder()
+                    .orderId(makingProductOrder.getId())
+                    .trackingNumber(TRACKING_NUMBER)
+                    .build();
+
+            // when
+            orderManageService.registerTrackingNumber(requestDto);
+
+            // then
+            assertThat(makingProductOrder.getOrderStatus()).isEqualTo(PREPARING_DELIVERY);
+        }
+
+        @Test
+        @DisplayName("주문의 상태가 '제작중'이 아니라면 예외가 발생한다")
+        void ifOrderStatusIsNotMakingProductThenThrowException() {
+            TrackingNumberRegisterRequestDto requestDto = TrackingNumberRegisterRequestDto.builder()
+                    .orderId(preparingProductOrder.getId())
+                    .trackingNumber(TRACKING_NUMBER)
+                    .build();
+
+            assertThatThrownBy(() -> orderManageService.registerTrackingNumber(requestDto))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    @Nested
+    class updateOrder {
+        @Test
+        @DisplayName("주문 정보를 수정한다")
+        void updateOrderInfo() {
+            // given
+            PaymentApproveResult newApproveResult = NEW_PAYMENT_APPROVE_RESULT_FIXTURE.getInstanceWith(order.getId());
+
+            OrderUpdateRequestDto requestDto = OrderUpdateRequestDto.builder()
+                    .orderId(order.getId())
+                    .approveResult(newApproveResult)
+                    .deliveryInfo(NEW_DELIVERY)
+                    .build();
+
+            // when
+            orderManageService.updateOrder(requestDto);
+
+            // then
+            assertThat(order.getApproveResult()).isEqualTo(newApproveResult);
+            assertThat(order.getDelivery()).isEqualTo(NEW_DELIVERY);
+        }
+    }
+
+    @Nested
+    class removeOrder {
+        @Test
+        @DisplayName("주문을 제거한다")
+        void deleteOrder() {
+            orderManageService.removeOrder(order.getId());
+
+            assertThat(orderRepository.findById(order.getId())).isEmpty();
+        }
+    }
+
+    private OrderInfoResponseDto findDtoById(long id, List<OrderInfoResponseDto> dtos) {
+        return dtos.stream()
+                .filter(dto -> dto.id().equals(id))
+                .findAny()
+                .orElseThrow(DTO_NOT_FOUND);
+    }
+
+    private boolean isEqualWithoutItem(Order order, OrderInfoResponseDto dto) {
+        return Objects.equals(order.getId(), dto.id()) &&
+                Objects.equals(order.getApproveResult(), dto.approveResult()) &&
+                Objects.equals(order.getDelivery(), dto.deliveryInfo()) &&
+                Objects.equals(order.getOrderStatus(), dto.status()) &&
+                Objects.equals(order.getCreatedAt(), dto.createAt()) &&
+                Objects.equals(order.getUpdatedAt(), dto.updatedAt());
+    }
+}

--- a/src/test/java/goodspace/backend/fixture/DeliveryFixture.java
+++ b/src/test/java/goodspace/backend/fixture/DeliveryFixture.java
@@ -1,0 +1,56 @@
+package goodspace.backend.fixture;
+
+import goodspace.backend.user.domain.Delivery;
+
+public enum DeliveryFixture {
+    A(
+        "A Recipient",
+            "01012345678",
+            "01011112222",
+            "10101",
+            "A Address",
+            "A Detailed Address"
+    ),
+    B(
+            "B Recipient",
+            "01023456789",
+            "01022222222",
+            "20202",
+            "B Address",
+            "B Detailed Address"
+    );
+
+    private final String recipient;
+    private final String contactNumber1;
+    private final String contactNumber2;
+    private final String postalCode;
+    private final String address;
+    private final String detailedAddress;
+
+    DeliveryFixture(
+            String recipient,
+            String contactNumber1,
+            String contactNumber2,
+            String postalCode,
+            String address,
+            String detailedAddress
+    ) {
+        this.recipient = recipient;
+        this.contactNumber1 = contactNumber1;
+        this.contactNumber2 = contactNumber2;
+        this.postalCode = postalCode;
+        this.address = address;
+        this.detailedAddress = detailedAddress;
+    }
+
+    public Delivery getInstance() {
+        return Delivery.builder()
+                .recipient(recipient)
+                .contactNumber1(contactNumber1)
+                .contactNumber2(contactNumber2)
+                .postalCode(postalCode)
+                .address(address)
+                .detailedAddress(detailedAddress)
+                .build();
+    }
+}

--- a/src/test/java/goodspace/backend/fixture/PaymentApproveResultFixture.java
+++ b/src/test/java/goodspace/backend/fixture/PaymentApproveResultFixture.java
@@ -1,0 +1,244 @@
+package goodspace.backend.fixture;
+
+import goodspace.backend.order.domain.PaymentApproveResult;
+import goodspace.backend.order.domain.PaymentApproveResult.CardInfo;
+
+public enum PaymentApproveResultFixture {
+    A(
+            "0000",
+            "정상 처리되었습니다.",
+            "UT0000113m01012111051714341073",
+            null,
+            "2021-11-05T17:14:35.150+0900",
+            "63b251b31c990eebef1a9f4fcc19e77bdbc8f64cf1066a29670f8627186865cd",
+            "paid",
+            "2021-11-05T17:14:35.000+0900",
+            "0",
+            "0",
+            "CARD",
+            1004,
+            1004,
+            "니이스페이-상품",
+            null,
+            false,
+            "KRW",
+            "pc",
+            "000000",
+            null, null, null,
+            "https://npg.nicepay.co.kr/issue/IssueLoader.do?tid=UT0000113m01012111051714341073",
+            null,
+            false,
+            null,
+            null,
+            CardInfo.builder()
+                    .cardCode("04")
+                    .cardName("삼성")
+                    .cardNum("12341234****1234")
+                    .cardQuota(0)
+                    .interestFree(false)
+                    .cardType("credit")
+                    .canPartCancel(true)
+                    .acquCardCode("04")
+                    .acquCardName("삼성")
+                    .build()
+    ),
+    B(
+            "1001",
+            "부분 승인되었습니다.",
+            "UT0000113m01012121051714341073",
+            null,
+            "2021-12-01T12:00:00.000+0900",
+            "abc123xyz456sig789signatureb",
+            "partially_paid",
+            "2021-12-01T12:01:00.000+0900",
+            "0",
+            "2021-12-01T12:05:00.000+0900",
+            "VBANK",
+            8000,
+            2000,
+            "부분결제 상품",
+            "B_RESERVED",
+            true,
+            "KRW",
+            "mobile",
+            "111111",
+            "이영희", "01023456789", "lee@example.com",
+            "https://npg.nicepay.co.kr/issue/IssueLoader.do?tid=UT0000113m01012121051714341073",
+            "mallUserB",
+            true,
+            "01087654321",
+            "KCP",
+            CardInfo.builder()
+                    .cardCode("05")
+                    .cardName("현대")
+                    .cardNum("43214321****4321")
+                    .cardQuota(2)
+                    .interestFree(true)
+                    .cardType("credit")
+                    .canPartCancel(false)
+                    .acquCardCode("05")
+                    .acquCardName("현대")
+                    .build()
+    ),
+    C(
+            "9999",
+            "결제 실패",
+            "UT0000113m01012131051714341073",
+            "UT0000113m01012131051714341073-CANCEL",
+            "2021-12-15T18:30:00.000+0900",
+            "sig-fail-20211215",
+            "failed",
+            null,
+            "2021-12-15T18:31:00.000+0900",
+            "2021-12-15T18:32:00.000+0900",
+            "CASH",
+            15000,
+            0,
+            "실패 상품",
+            "C_RESERVED",
+            false,
+            "USD",
+            "app",
+            "999999",
+            "박지민", "01034567890", "park@example.com",
+            "https://npg.nicepay.co.kr/issue/IssueLoader.do?tid=UT0000113m01012131051714341073",
+            "mallUserC",
+            false,
+            "01099887766",
+            "PG",
+            CardInfo.builder()
+                    .cardCode("06")
+                    .cardName("롯데")
+                    .cardNum("98769876****9876")
+                    .cardQuota(12)
+                    .interestFree(false)
+                    .cardType("할부")
+                    .canPartCancel(true)
+                    .acquCardCode("06")
+                    .acquCardName("롯데")
+                    .build()
+    );
+
+    private final String resultCode;
+    private final String resultMsg;
+    private final String tid;
+    private final String cancelledTid;
+    private final String ediDate;
+    private final String signature;
+    private final String status;
+    private final String paidAt;
+    private final String failedAt;
+    private final String cancelledAt;
+    private final String payMethod;
+    private final Integer amount;
+    private final Integer balanceAmt;
+    private final String goodsName;
+    private final String mallReserved;
+    private final Boolean useEscrow;
+    private final String currency;
+    private final String channel;
+    private final String approveNo;
+    private final String buyerName;
+    private final String buyerTel;
+    private final String buyerEmail;
+    private final String receiptUrl;
+    private final String mallUserId;
+    private final Boolean issuedCashReceipt;
+    private final String cellphone;
+    private final String messageSource;
+    private final CardInfo card;
+
+    PaymentApproveResultFixture(
+            String resultCode,
+            String resultMsg,
+            String tid,
+            String cancelledTid,
+            String ediDate,
+            String signature,
+            String status,
+            String paidAt,
+            String failedAt,
+            String cancelledAt,
+            String payMethod,
+            Integer amount,
+            Integer balanceAmt,
+            String goodsName,
+            String mallReserved,
+            Boolean useEscrow,
+            String currency,
+            String channel,
+            String approveNo,
+            String buyerName,
+            String buyerTel,
+            String buyerEmail,
+            String receiptUrl,
+            String mallUserId,
+            Boolean issuedCashReceipt,
+            String cellphone,
+            String messageSource,
+            CardInfo card
+    ) {
+        this.resultCode = resultCode;
+        this.resultMsg = resultMsg;
+        this.tid = tid;
+        this.cancelledTid = cancelledTid;
+        this.ediDate = ediDate;
+        this.signature = signature;
+        this.status = status;
+        this.paidAt = paidAt;
+        this.failedAt = failedAt;
+        this.cancelledAt = cancelledAt;
+        this.payMethod = payMethod;
+        this.amount = amount;
+        this.balanceAmt = balanceAmt;
+        this.goodsName = goodsName;
+        this.mallReserved = mallReserved;
+        this.useEscrow = useEscrow;
+        this.currency = currency;
+        this.channel = channel;
+        this.approveNo = approveNo;
+        this.buyerName = buyerName;
+        this.buyerTel = buyerTel;
+        this.buyerEmail = buyerEmail;
+        this.receiptUrl = receiptUrl;
+        this.mallUserId = mallUserId;
+        this.issuedCashReceipt = issuedCashReceipt;
+        this.cellphone = cellphone;
+        this.messageSource = messageSource;
+        this.card = card;
+    }
+
+    public PaymentApproveResult getInstanceWith(long orderId) {
+        return PaymentApproveResult.builder()
+                .resultCode(resultCode)
+                .resultMsg(resultMsg)
+                .tid(tid)
+                .cancelledTid(cancelledTid)
+                .orderId(orderId)
+                .ediDate(ediDate)
+                .signature(signature)
+                .status(status)
+                .paidAt(paidAt)
+                .failedAt(failedAt)
+                .cancelledAt(cancelledAt)
+                .payMethod(payMethod)
+                .amount(amount)
+                .balanceAmt(balanceAmt)
+                .goodsName(goodsName)
+                .mallReserved(mallReserved)
+                .useEscrow(useEscrow)
+                .currency(currency)
+                .channel(channel)
+                .approveNo(approveNo)
+                .buyerName(buyerName)
+                .buyerTel(buyerTel)
+                .buyerEmail(buyerEmail)
+                .receiptUrl(receiptUrl)
+                .mallUserId(mallUserId)
+                .issuedCashReceipt(issuedCashReceipt)
+                .cellphone(cellphone)
+                .messageSource(messageSource)
+                .card(card)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
주문을 조회하고 상태를 수정할 수 있는 API를 구현했습니다.
관리자 페이지를 통해 주문의 상태를 변경할 수 있습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#143 
