### PR TITLE
[feat/#158] 비밀번호 재설정 API 추가

### DIFF
--- a/src/main/java/goodspace/backend/global/security/SecurityConfig.java
+++ b/src/main/java/goodspace/backend/global/security/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
                         .requestMatchers("/client/**").permitAll() // 클라이언트 상품 페이지 관련
                         .requestMatchers("/stylesheets/**","/api/**").permitAll()
                         .requestMatchers("/meta/**").permitAll() // 카테고리/타입 관련
+                        .requestMatchers("/user/forget-password").permitAll() // 이메일 인증을 통한 비밀번호 재설정
                         .requestMatchers("/admin/**").hasRole("ADMIN") // 관리자 전용 API
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/goodspace/backend/user/controller/UserController.java
+++ b/src/main/java/goodspace/backend/user/controller/UserController.java
@@ -49,7 +49,7 @@ public class UserController {
 
     @PatchMapping("/password")
     @Operation(
-            summary = "비밀번호 수정",
+            summary = "비밀번호 수정(마이페이지 용도)",
             description = "비밀번호를 수정합니다."
     )
     public ResponseEntity<RefreshTokenResponseDto> updatePassword(
@@ -58,6 +58,19 @@ public class UserController {
     ) {
         long id = principalUtil.findIdFromPrincipal(principal);
         RefreshTokenResponseDto responseDto = userService.updatePassword(id, requestDto);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @PatchMapping("/forget-password")
+    @Operation(
+            summary = "비밀번호 수정(비밀번호를 잊어버렸을 때)",
+            description = "비밀번호를 수정합니다. 사전에 이메일 인증이 필요한 대신 AccessToken을 필요로 하지 않습니다."
+    )
+    public ResponseEntity<RefreshTokenResponseDto> updatePasswordByVerifiedEmail(
+            @RequestBody PasswordUpdateByVerifiedEmailRequestDto requestDto
+    ) {
+        RefreshTokenResponseDto responseDto = userService.updatePasswordByVerifiedEmail(requestDto);
 
         return ResponseEntity.ok(responseDto);
     }

--- a/src/main/java/goodspace/backend/user/dto/PasswordUpdateByVerifiedEmailRequestDto.java
+++ b/src/main/java/goodspace/backend/user/dto/PasswordUpdateByVerifiedEmailRequestDto.java
@@ -1,0 +1,10 @@
+package goodspace.backend.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PasswordUpdateByVerifiedEmailRequestDto(
+        String email,
+        String password
+) {
+}

--- a/src/main/java/goodspace/backend/user/service/UserService.java
+++ b/src/main/java/goodspace/backend/user/service/UserService.java
@@ -99,6 +99,22 @@ public class UserService {
     }
 
     @Transactional
+    public RefreshTokenResponseDto updatePasswordByVerifiedEmail(PasswordUpdateByVerifiedEmailRequestDto requestDto) {
+        GoodSpaceUser user = userRepository.findGoodSpaceUserByEmail(requestDto.email())
+                .orElseThrow(USER_NOT_FOUND);
+        checkEmailVerification(requestDto.email());
+
+        validatePassword(requestDto.password());
+
+        String encodedPassword = passwordEncoder.encode(requestDto.password());
+        user.updatePassword(encodedPassword);
+
+        return RefreshTokenResponseDto.builder()
+                .refreshToken(createNewRefreshToken(user))
+                .build();
+    }
+
+    @Transactional
     public RefreshTokenResponseDto updateEmail(long userId, EmailUpdateRequestDto requestDto) {
         checkEmailVerification(requestDto.email());
 

--- a/src/test/java/goodspace/backend/fixture/EmailVerificationFixture.java
+++ b/src/test/java/goodspace/backend/fixture/EmailVerificationFixture.java
@@ -5,6 +5,12 @@ import goodspace.backend.email.entity.EmailVerification;
 import java.time.LocalDateTime;
 
 public enum EmailVerificationFixture {
+    DEFAULT(
+            "default@email.com",
+            "444555",
+            LocalDateTime.now().plusMinutes(5),
+            true
+    ),
     NOT_VERIFIED(
             "not@email.com",
             "123123",


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
비밀번호를 잊었을 때를 위한 비밀번호 재설정 API를 추가했습니다.
기존의 비밀번호 재설정 API는 JWT를 요구하기 때문에, JWT 대신 이메일 인증을 기반으로 사용자를 식별하는 API를 별도로 추가했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#158 
