### PR TITLE
[fix/#181] OrderInfoResponseDto의 JSON 파싱 문제 해결

### DIFF
--- a/src/main/java/goodspace/backend/admin/dto/order/OrderInfoResponseDto.java
+++ b/src/main/java/goodspace/backend/admin/dto/order/OrderInfoResponseDto.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Builder
 public record OrderInfoResponseDto(
         Long id,
-        PaymentApproveResult approveResult,
+        PaymentApproveResultResponseDto approveResult,
         DeliveryInfo deliveryInfo,
         OrderStatus status,
         LocalDateTime createAt,
@@ -26,10 +26,11 @@ public record OrderInfoResponseDto(
                 .map(OrderCartItem::getItem)
                 .map(ItemInfoResponseDto::from)
                 .toList();
+        PaymentApproveResult approveResult = order.getApproveResult();
 
         return OrderInfoResponseDto.builder()
                 .id(order.getId())
-                .approveResult(order.getApproveResult())
+                .approveResult(approveResult == null ? null : PaymentApproveResultResponseDto.from(approveResult))
                 .deliveryInfo(order.getDeliveryInfo())
                 .status(order.getOrderStatus())
                 .createAt(order.getCreatedAt())

--- a/src/main/java/goodspace/backend/admin/dto/order/PaymentApproveResultResponseDto.java
+++ b/src/main/java/goodspace/backend/admin/dto/order/PaymentApproveResultResponseDto.java
@@ -1,0 +1,199 @@
+package goodspace.backend.admin.dto.order;
+
+import goodspace.backend.order.domain.PaymentApproveResult;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record PaymentApproveResultResponseDto(
+        String resultCode,
+        String resultMsg,
+        String tid,
+        String cancelledTid,
+        Long orderId,
+        String ediDate,
+        String signature,
+        String status,
+        String paidAt,
+        String failedAt,
+        String cancelledAt,
+        String payMethod,
+        Integer amount,
+        Integer balanceAmt,
+        String goodsName,
+        String mallReserved,
+        Boolean useEscrow,
+        String currency,
+        String channel,
+        String approveNo,
+        String buyerName,
+        String buyerTel,
+        String buyerEmail,
+        String receiptUrl,
+        String mallUserId,
+        Boolean issuedCashReceipt,
+        String cellphone,
+        String messageSource,
+        BankDto bank,
+        List<CancelInfoDto> cancels,
+        List<CashReceiptInfoDto> cashReceipts,
+        VbankInfoDto vbank,
+        CouponDto coupon,
+        CardInfoDto card
+) {
+    public static PaymentApproveResultResponseDto from(PaymentApproveResult approveResult) {
+        return PaymentApproveResultResponseDto.builder()
+                .resultCode(approveResult.getResultCode())
+                .resultMsg(approveResult.getResultMsg())
+                .tid(approveResult.getTid())
+                .cancelledTid(approveResult.getCancelledTid())
+                .orderId(approveResult.getOrderId())
+                .ediDate(approveResult.getEdiDate())
+                .signature(approveResult.getSignature())
+                .status(approveResult.getStatus())
+                .paidAt(approveResult.getPaidAt())
+                .failedAt(approveResult.getFailedAt())
+                .cancelledAt(approveResult.getCancelledAt())
+                .payMethod(approveResult.getPayMethod())
+                .amount(approveResult.getAmount())
+                .balanceAmt(approveResult.getBalanceAmt())
+                .goodsName(approveResult.getGoodsName())
+                .mallReserved(approveResult.getMallReserved())
+                .useEscrow(approveResult.getUseEscrow())
+                .currency(approveResult.getCurrency())
+                .channel(approveResult.getChannel())
+                .approveNo(approveResult.getApproveNo())
+                .buyerName(approveResult.getBuyerName())
+                .buyerTel(approveResult.getBuyerTel())
+                .buyerEmail(approveResult.getBuyerEmail())
+                .receiptUrl(approveResult.getReceiptUrl())
+                .mallUserId(approveResult.getMallUserId())
+                .issuedCashReceipt(approveResult.getIssuedCashReceipt())
+                .cellphone(approveResult.getCellphone())
+                .messageSource(approveResult.getMessageSource())
+                .bank(approveResult.getBank() != null ? BankDto.from(approveResult.getBank()) : null)
+                .cancels(approveResult.getCancels() != null
+                        ? approveResult.getCancels().stream().map(CancelInfoDto::from).toList()
+                        : null)
+                .cashReceipts(approveResult.getCashReceipts() != null
+                        ? approveResult.getCashReceipts().stream().map(CashReceiptInfoDto::from).toList()
+                        : null)
+                .vbank(approveResult.getVbank() != null ? VbankInfoDto.from(approveResult.getVbank()) : null)
+                .coupon(approveResult.getCoupon() != null ? CouponDto.from(approveResult.getCoupon()) : null)
+                .card(approveResult.getCard() != null ? CardInfoDto.from(approveResult.getCard()) : null)
+                .build();
+    }
+
+    @Builder
+    public record CancelInfoDto(
+            String cancelDate,
+            String cancelAmount,
+            String cancelReason,
+            String cancelType
+    ) {
+        public static CancelInfoDto from(PaymentApproveResult.CancelInfo cancelInfo) {
+            return CancelInfoDto.builder()
+                    .cancelDate(cancelInfo.getCancelDate())
+                    .cancelAmount(cancelInfo.getCancelAmount())
+                    .cancelReason(cancelInfo.getCancelReason())
+                    .cancelType(cancelInfo.getCancelType())
+                    .build();
+        }
+    }
+
+    @Builder
+    public record CashReceiptInfoDto(
+            String receiptId,
+            String orgTid,
+            String status,
+            Integer amount,
+            Integer taxFreeAmt,
+            String receiptType,
+            String issueNo,
+            String receiptUrl
+    ) {
+        public static CashReceiptInfoDto from(PaymentApproveResult.CashReceiptInfo info) {
+            return CashReceiptInfoDto.builder()
+                    .receiptId(info.getReceiptId())
+                    .orgTid(info.getOrgTid())
+                    .status(info.getStatus())
+                    .amount(info.getAmount())
+                    .taxFreeAmt(info.getTaxFreeAmt())
+                    .receiptType(info.getReceiptType())
+                    .issueNo(info.getIssueNo())
+                    .receiptUrl(info.getReceiptUrl())
+                    .build();
+        }
+    }
+
+    @Builder
+    public record CouponDto(
+            int couponAmt
+    ) {
+        public static CouponDto from(PaymentApproveResult.Coupon coupon) {
+            return CouponDto.builder()
+                    .couponAmt(coupon.getCouponAmt())
+                    .build();
+        }
+    }
+
+    @Builder
+    public record CardInfoDto(
+            String cardCode,
+            String cardName,
+            String cardNum,
+            int cardQuota,
+            boolean interestFree,
+            String cardType,
+            boolean canPartCancel,
+            String acquCardCode,
+            String acquCardName
+    ) {
+        public static CardInfoDto from(PaymentApproveResult.CardInfo cardInfo) {
+            return CardInfoDto.builder()
+                    .cardCode(cardInfo.getCardCode())
+                    .cardName(cardInfo.getCardName())
+                    .cardNum(cardInfo.getCardNum())
+                    .cardQuota(cardInfo.getCardQuota())
+                    .interestFree(cardInfo.isInterestFree())
+                    .cardType(cardInfo.getCardType())
+                    .canPartCancel(cardInfo.isCanPartCancel())
+                    .acquCardCode(cardInfo.getAcquCardCode())
+                    .acquCardName(cardInfo.getAcquCardName())
+                    .build();
+        }
+    }
+
+    @Builder
+    public record VbankInfoDto(
+            String vbankName,
+            String vbankNumber,
+            String vbankCode,
+            String vbankExpDate,
+            String vbankHolder
+    ) {
+        public static VbankInfoDto from(PaymentApproveResult.VbankInfo vbank) {
+            return VbankInfoDto.builder()
+                    .vbankName(vbank.getVbankName())
+                    .vbankNumber(vbank.getVbankNumber())
+                    .vbankCode(vbank.getVbankCode())
+                    .vbankExpDate(vbank.getVbankExpDate())
+                    .vbankHolder(vbank.getVbankHolder())
+                    .build();
+        }
+    }
+
+    @Builder
+    public record BankDto(
+            String bankCode,
+            String bankName
+    ) {
+        public static BankDto from(PaymentApproveResult.Bank bank) {
+            return BankDto.builder()
+                    .bankCode(bank.getBankCode())
+                    .bankName(bank.getBankName())
+                    .build();
+        }
+    }
+}

--- a/src/test/java/goodspace/backend/admin/service/order/OrderManageServiceTest.java
+++ b/src/test/java/goodspace/backend/admin/service/order/OrderManageServiceTest.java
@@ -2,6 +2,7 @@ package goodspace.backend.admin.service.order;
 
 import goodspace.backend.admin.dto.order.OrderInfoResponseDto;
 import goodspace.backend.admin.dto.order.OrderUpdateRequestDto;
+import goodspace.backend.admin.dto.order.PaymentApproveResultResponseDto;
 import goodspace.backend.admin.dto.order.TrackingNumberRegisterRequestDto;
 import goodspace.backend.fixture.DeliveryFixture;
 import goodspace.backend.fixture.GoodSpaceUserFixture;
@@ -205,10 +206,18 @@ class OrderManageServiceTest {
 
     private boolean isEqualWithoutItem(Order order, OrderInfoResponseDto dto) {
         return Objects.equals(order.getId(), dto.id()) &&
-                Objects.equals(order.getApproveResult(), dto.approveResult()) &&
+                isEqual(order.getApproveResult(), dto.approveResult()) &&
                 Objects.equals(order.getDeliveryInfo(), dto.deliveryInfo()) &&
                 Objects.equals(order.getOrderStatus(), dto.status()) &&
                 Objects.equals(order.getCreatedAt(), dto.createAt()) &&
                 Objects.equals(order.getUpdatedAt(), dto.updatedAt());
+    }
+
+    private boolean isEqual(PaymentApproveResult approveResult, PaymentApproveResultResponseDto dto) {
+        if (approveResult == null && dto == null) return true;
+        if (approveResult == null || dto == null) return false;
+
+        PaymentApproveResultResponseDto converted = PaymentApproveResultResponseDto.from(approveResult);
+        return Objects.equals(converted, dto);
     }
 }


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
`PaymentApproveResult`를 그대로 사용해서 발생한 JSON 파싱 문제를 해결했습니다.
`PaymentApproveResultResponseDto`를 사용하도록 수정했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#181 