### PR TITLE
[fix/#198] PurchaseHistoryResponseDto의 OffsetDateTime 파싱 문제 해결

### DIFF
--- a/src/main/java/goodspace/backend/global/parser/DateTimeParsers.java
+++ b/src/main/java/goodspace/backend/global/parser/DateTimeParsers.java
@@ -1,0 +1,51 @@
+package goodspace.backend.global.parser;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DateTimeParsers {
+    // yyyy-MM-dd'T'HH:mm:ss[.fraction] + offset(: 포함)
+    private static final DateTimeFormatter OFFSET_WITH_COLON = new DateTimeFormatterBuilder()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            .appendOffset("+HH:MM", "Z")
+            .toFormatter();
+
+    // yyyy-MM-dd'T'HH:mm:ss[.fraction] + offset(: 없이)
+    private static final DateTimeFormatter OFFSET_WITHOUT_COLON = new DateTimeFormatterBuilder()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            .appendOffset("+HHMM", "Z")
+            .toFormatter();
+
+    // 드물지만 +09 같은 형태 지원
+    private static final DateTimeFormatter OFFSET_HOURS_ONLY = new DateTimeFormatterBuilder()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            .appendOffset("+HH", "Z")
+            .toFormatter();
+
+    private static final List<DateTimeFormatter> CANDIDATES = List.of(
+            OFFSET_WITH_COLON,
+            OFFSET_WITHOUT_COLON,
+            OFFSET_HOURS_ONLY
+    );
+
+    public static OffsetDateTime parseOffsetDateTime(String text) {
+        if (text == null || text.isBlank()) {
+            return null;
+        }
+
+        for (DateTimeFormatter parseFormat : CANDIDATES) {
+            try {
+                return OffsetDateTime.parse(text, parseFormat);
+            } catch (DateTimeParseException ignore) { /* try next */ }
+        }
+
+        return OffsetDateTime.parse(text);
+    }
+}

--- a/src/main/java/goodspace/backend/user/dto/PurchaseHistoryResponseDto.java
+++ b/src/main/java/goodspace/backend/user/dto/PurchaseHistoryResponseDto.java
@@ -1,5 +1,6 @@
 package goodspace.backend.user.dto;
 
+import goodspace.backend.global.parser.DateTimeParsers;
 import goodspace.backend.order.domain.Order;
 import goodspace.backend.order.domain.OrderCartItem;
 import goodspace.backend.order.domain.OrderStatus;
@@ -22,7 +23,7 @@ public record PurchaseHistoryResponseDto(
         PaymentApproveResult approveResult = order.getApproveResult();
 
         return PurchaseHistoryResponseDto.builder()
-                .date(approveResult.getPaidAt() == null ? null : OffsetDateTime.parse(approveResult.getPaidAt()))
+                .date(DateTimeParsers.parseOffsetDateTime(approveResult.getPaidAt()))
                 .id(order.getId())
                 .itemInfo(approveResult.getGoodsName())
                 .totalQuantity(getTotalQuantity(order.getOrderCartItems()))


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
`PaymentApproveResult`의 `paidAt` 문자열 형식이 `OffsetDateTime`의 기본 파서와 호환되지 않는 문제를 해결했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#198 