### PR TITLE
[fix/#198] PurchaseHistoryResponseDto에 null 방어 로직 구현

### DIFF
--- a/src/main/java/goodspace/backend/user/dto/PurchaseHistoryResponseDto.java
+++ b/src/main/java/goodspace/backend/user/dto/PurchaseHistoryResponseDto.java
@@ -23,11 +23,11 @@ public record PurchaseHistoryResponseDto(
         PaymentApproveResult approveResult = order.getApproveResult();
 
         return PurchaseHistoryResponseDto.builder()
-                .date(DateTimeParsers.parseOffsetDateTime(approveResult.getPaidAt()))
+                .date(approveResult == null ? null : DateTimeParsers.parseOffsetDateTime(approveResult.getPaidAt()))
                 .id(order.getId())
-                .itemInfo(approveResult.getGoodsName())
+                .itemInfo(approveResult == null ? null: approveResult.getGoodsName())
                 .totalQuantity(getTotalQuantity(order.getOrderCartItems()))
-                .amount(approveResult.getAmount())
+                .amount(approveResult == null ? null : approveResult.getAmount())
                 .status(order.getOrderStatus())
                 .build();
     }

--- a/src/main/java/goodspace/backend/user/service/UserService.java
+++ b/src/main/java/goodspace/backend/user/service/UserService.java
@@ -30,7 +30,6 @@ public class UserService {
     private static final Supplier<IllegalArgumentException> ILLEGAL_PASSWORD = () -> new IllegalArgumentException("부적절한 비밀번호입니다.");
     private static final Supplier<EntityNotFoundException> VERIFICATION_NOT_FOUND = () -> new EntityNotFoundException("이메일 인증 정보를 찾을 수 없습니다.");
     private static final Supplier<IllegalStateException> NOT_VERIFIED = () -> new IllegalStateException("인증되지 않은 이메일입니다.");
-    private static final Supplier<IllegalStateException> ILLEGAL_STATE_ORDER = () -> new IllegalStateException("처리되지 않은 주문이 있습니다.");
 
     private final UserRepository userRepository;
     private final EmailVerificationRepository emailVerificationRepository;
@@ -140,7 +139,6 @@ public class UserService {
         if (hasIllegalStateOrder(user.getOrders())) {
             // TODO: 부적절한 상태의 주문이 있을 경우 개발자에게 알려야 함
             log.error("ERROR: ApproveResult가 매핑되지 않은 Order 발생 (USER ID: {})", userId);
-            throw ILLEGAL_STATE_ORDER.get();
         }
 
         return user.getOrders().stream()


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
`PurchaseHistoryResponseDto`에 null 방어 로직을 구현하여 구매내역 조회시 NPE가 발생하던 문제를 해결했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#198 