### PR TITLE
[feat/#205] 회원 이름 조회 API 구현

### DIFF
--- a/src/main/java/goodspace/backend/user/controller/UserController.java
+++ b/src/main/java/goodspace/backend/user/controller/UserController.java
@@ -33,6 +33,18 @@ public class UserController {
         return ResponseEntity.ok().body(userService.getUserInfo(id));
     }
 
+    @GetMapping("/name")
+    @Operation(
+            summary = "이름 불러오기",
+            description = "회원 이름을 조회합니다."
+    )
+    public ResponseEntity<UserNameResponseDto> getUserName(Principal principal) {
+        long id = principalUtil.findIdFromPrincipal(principal);
+        UserNameResponseDto responseDto = userService.getName(id);
+
+        return ResponseEntity.ok(responseDto);
+    }
+
     @PatchMapping("/updateMyPage")
     @Operation(
             summary = "정보 수정",

--- a/src/main/java/goodspace/backend/user/dto/UserNameResponseDto.java
+++ b/src/main/java/goodspace/backend/user/dto/UserNameResponseDto.java
@@ -1,0 +1,15 @@
+package goodspace.backend.user.dto;
+
+import goodspace.backend.user.domain.User;
+import lombok.Builder;
+
+@Builder
+public record UserNameResponseDto(
+        String name
+) {
+    public static UserNameResponseDto from(User user) {
+        return UserNameResponseDto.builder()
+                .name(user.getName())
+                .build();
+    }
+}

--- a/src/main/java/goodspace/backend/user/service/UserService.java
+++ b/src/main/java/goodspace/backend/user/service/UserService.java
@@ -71,6 +71,13 @@ public class UserService {
     }
 
     @Transactional
+    public UserNameResponseDto getName(long userId) {
+        return userRepository.findById(userId)
+                .map(UserNameResponseDto::from)
+                .orElseThrow(USER_NOT_FOUND);
+    }
+
+    @Transactional
     public String updateMyPage(long userId, UserMyPageDto userMyPageDto) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("User not found while updating MyPage Information."));

--- a/src/test/java/goodspace/backend/user/service/UserServiceTest.java
+++ b/src/test/java/goodspace/backend/user/service/UserServiceTest.java
@@ -89,6 +89,22 @@ class UserServiceTest {
     }
 
     @Nested
+    class getName {
+        @Test
+        @DisplayName("회원 이름을 조회한다")
+        void getNameOfUser() {
+            // given
+            String expectedResult = user.getName();
+
+            // when
+            UserNameResponseDto actualResult = userService.getName(user.getId());
+
+            // then
+            assertThat(actualResult.name()).isEqualTo(expectedResult);
+        }
+    }
+
+    @Nested
     class updatePassword {
         @Test
         @DisplayName("비밀번호를 변경한다")


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
마이페이지 뷰를 위해, 회원 이름 조회 API를 구현했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#205 