### PR TITLE
[fix/#207] 주문 API 소규모 변경

### DIFF
--- a/src/main/java/goodspace/backend/order/dto/OrderInfoDto.java
+++ b/src/main/java/goodspace/backend/order/dto/OrderInfoDto.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class OrderInfoDto {
+    private String email;
     private String name;
     private String phoneNumber;
     private String recipient;

--- a/src/main/java/goodspace/backend/order/dto/OrderRequestDto.java
+++ b/src/main/java/goodspace/backend/order/dto/OrderRequestDto.java
@@ -14,8 +14,4 @@ public class OrderRequestDto {
     private List<OrderCartItemDto> orderCartItemDtos;
     private OrderInfoDto orderInfo;
     private Boolean requireUpdateUserInfo;
-
-    public DeliveryInfo getDeliveryInfo() {
-        return orderInfo.toDeliveryInfo();
-    }
 }

--- a/src/main/java/goodspace/backend/order/service/OrderService.java
+++ b/src/main/java/goodspace/backend/order/service/OrderService.java
@@ -36,7 +36,7 @@ public class OrderService {
 
         Order order = Order.builder()
                 .user(user)
-                .deliveryInfo(orderRequest.getDeliveryInfo())
+                .deliveryInfo(orderRequest.getOrderInfo().toDeliveryInfo())
                 .build();
 
         List<OrderCartItem> orderCartItems = orderRequest.getOrderCartItemDtos().stream()


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
후에 사용하기 위해 `email` 정보를 같이 받아오도록 했습니다.
Swagger 오동작으로 인해 get 메서드를 제거했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#207 
