### PR TITLE
[feat/#228] 관리자용 등기번호 API 구현

### DIFF
--- a/src/main/java/goodspace/backend/admin/controller/OrderManageController.java
+++ b/src/main/java/goodspace/backend/admin/controller/OrderManageController.java
@@ -2,6 +2,8 @@ package goodspace.backend.admin.controller;
 
 import goodspace.backend.admin.dto.order.OrderInfoResponseDto;
 import goodspace.backend.admin.dto.order.OrderUpdateRequestDto;
+import goodspace.backend.admin.dto.order.TrackingNumberRegisterRequestDto;
+import goodspace.backend.admin.dto.order.TrackingNumberUpdateRequestDto;
 import goodspace.backend.admin.service.order.OrderManageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -61,6 +63,28 @@ public class OrderManageController {
     )
     public ResponseEntity<Void> acceptOrder(@RequestParam Long orderId) {
         orderManageService.acceptOrder(orderId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/tracking-number")
+    @Operation(
+            summary = "등기번호 입력",
+            description = "주문에 등기번호를 입력합니다. 주문의 상태를 '제작중'에서 '배송 준비중'으로 전이합니다."
+    )
+    public ResponseEntity<Void> registerTrackingNumber(@RequestBody TrackingNumberRegisterRequestDto requestDto) {
+        orderManageService.registerTrackingNumber(requestDto);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/tracking-number")
+    @Operation(
+            summary = "등기번호 수정",
+            description = "주문의 등기번호를 수정합니다."
+    )
+    public ResponseEntity<Void> updateTrackingNumber(@RequestBody TrackingNumberUpdateRequestDto requestDto) {
+        orderManageService.updateTrackingNumber(requestDto);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/goodspace/backend/admin/dto/order/TrackingNumberUpdateRequestDto.java
+++ b/src/main/java/goodspace/backend/admin/dto/order/TrackingNumberUpdateRequestDto.java
@@ -1,0 +1,10 @@
+package goodspace.backend.admin.dto.order;
+
+import lombok.Builder;
+
+@Builder
+public record TrackingNumberUpdateRequestDto(
+        Long orderId,
+        String trackingNumber
+) {
+}

--- a/src/main/java/goodspace/backend/admin/service/order/OrderManageService.java
+++ b/src/main/java/goodspace/backend/admin/service/order/OrderManageService.java
@@ -3,6 +3,7 @@ package goodspace.backend.admin.service.order;
 import goodspace.backend.admin.dto.order.OrderInfoResponseDto;
 import goodspace.backend.admin.dto.order.OrderUpdateRequestDto;
 import goodspace.backend.admin.dto.order.TrackingNumberRegisterRequestDto;
+import goodspace.backend.admin.dto.order.TrackingNumberUpdateRequestDto;
 
 import java.util.List;
 
@@ -12,6 +13,8 @@ public interface OrderManageService {
     void acceptOrder(long orderId);
 
     void registerTrackingNumber(TrackingNumberRegisterRequestDto requestDto);
+
+    void updateTrackingNumber(TrackingNumberUpdateRequestDto requestDto);
 
     void updateOrder(OrderUpdateRequestDto requestDto);
 

--- a/src/main/java/goodspace/backend/admin/service/order/OrderManageServiceImpl.java
+++ b/src/main/java/goodspace/backend/admin/service/order/OrderManageServiceImpl.java
@@ -3,6 +3,7 @@ package goodspace.backend.admin.service.order;
 import goodspace.backend.admin.dto.order.OrderInfoResponseDto;
 import goodspace.backend.admin.dto.order.OrderUpdateRequestDto;
 import goodspace.backend.admin.dto.order.TrackingNumberRegisterRequestDto;
+import goodspace.backend.admin.dto.order.TrackingNumberUpdateRequestDto;
 import goodspace.backend.order.domain.Order;
 import goodspace.backend.order.domain.OrderStatus;
 import goodspace.backend.order.repository.OrderRepository;
@@ -55,6 +56,19 @@ public class OrderManageServiceImpl implements OrderManageService {
 
         order.setTrackingNumber(requestDto.trackingNumber());
         order.updateOrderStatus(OrderStatus.PREPARING_DELIVERY);
+    }
+
+    @Override
+    @Transactional
+    public void updateTrackingNumber(TrackingNumberUpdateRequestDto requestDto) {
+        Order order = orderRepository.findById(requestDto.orderId())
+                .orElseThrow(ORDER_NOT_FOUND);
+
+        if (order.getOrderStatus() != OrderStatus.PREPARING_DELIVERY) {
+            throw ILLEGAL_ORDER_STATE.get();
+        }
+
+        order.setTrackingNumber(requestDto.trackingNumber());
     }
 
     @Override


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
관리자 페이지에서 사용할 등기번호 입력/수정 API를 구현했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#228 

## 📝 참고할 사항
`Service`단의 등기번호 입력 로직은 기존에 미리 구현해 둔 것을 사용했습니다.
