### PR TITLE
[chore/#228] 주문 조회 API에 등기번호 값 추가

### DIFF
--- a/src/main/java/goodspace/backend/admin/dto/order/OrderInfoResponseDto.java
+++ b/src/main/java/goodspace/backend/admin/dto/order/OrderInfoResponseDto.java
@@ -17,6 +17,7 @@ public record OrderInfoResponseDto(
         PaymentApproveResultDto approveResult,
         DeliveryInfo deliveryInfo,
         OrderStatus status,
+        String trackingNumber,
         LocalDateTime createAt,
         LocalDateTime updatedAt,
         List<ItemInfoResponseDto> items
@@ -33,6 +34,7 @@ public record OrderInfoResponseDto(
                 .approveResult(approveResult == null ? null : PaymentApproveResultDto.from(approveResult))
                 .deliveryInfo(order.getDeliveryInfo())
                 .status(order.getOrderStatus())
+                .trackingNumber(order.getTrackingNumber())
                 .createAt(order.getCreatedAt())
                 .updatedAt(order.getUpdatedAt())
                 .items(items)

--- a/src/test/java/goodspace/backend/admin/service/order/OrderManageServiceTest.java
+++ b/src/test/java/goodspace/backend/admin/service/order/OrderManageServiceTest.java
@@ -277,6 +277,7 @@ class OrderManageServiceTest {
                 isEqual(order.getApproveResult(), dto.approveResult()) &&
                 Objects.equals(order.getDeliveryInfo(), dto.deliveryInfo()) &&
                 Objects.equals(order.getOrderStatus(), dto.status()) &&
+                Objects.equals(order.getTrackingNumber(), dto.trackingNumber()) &&
                 Objects.equals(order.getCreatedAt(), dto.createAt()) &&
                 Objects.equals(order.getUpdatedAt(), dto.updatedAt());
     }


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
주문 조회 API의 응답 값에 등기번호를 추가했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#228 
